### PR TITLE
파일 업로드 구현(리뷰, 축제, 프로필)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// aws
+	implementation 'software.amazon.awssdk:s3:2.20.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kakao/festapick/config/S3Config.java
+++ b/src/main/java/kakao/festapick/config/S3Config.java
@@ -38,7 +38,9 @@ public class S3Config {
     public S3Client s3Client() {
         S3Client s3Client = S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create())
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
                 .build();
 
         return s3Client;

--- a/src/main/java/kakao/festapick/config/S3Config.java
+++ b/src/main/java/kakao/festapick/config/S3Config.java
@@ -1,0 +1,46 @@
+package kakao.festapick.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        S3Presigner.Builder builder = S3Presigner.builder()
+                .region(Region.of(region));
+
+        builder.credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+        ));
+
+        return builder.build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        S3Client s3Client = S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+
+        return s3Client;
+    }
+}

--- a/src/main/java/kakao/festapick/config/SecurityConfig.java
+++ b/src/main/java/kakao/festapick/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -54,7 +55,10 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth->auth
                 .requestMatchers("/api/users/**").authenticated()
                 .requestMatchers("/api/wishes/**").authenticated()
-                .requestMatchers("/api/reviews/**").authenticated()
+                .requestMatchers("/api/presigned-urls/**").authenticated()
+                .requestMatchers(HttpMethod.DELETE,"/api/reviews/**").authenticated()
+                .requestMatchers(HttpMethod.POST,"/api/reviews/**").authenticated()
+                .requestMatchers(HttpMethod.PUT,"/api/reviews/**").authenticated()
                 .requestMatchers("/admin/**").hasRole(UserRoleType.ADMIN.name())
                 .anyRequest().permitAll());
 

--- a/src/main/java/kakao/festapick/festival/controller/FestivalAdminController.java
+++ b/src/main/java/kakao/festapick/festival/controller/FestivalAdminController.java
@@ -3,10 +3,7 @@ package kakao.festapick.festival.controller;
 
 import jakarta.validation.Valid;
 import kakao.festapick.festival.domain.FestivalState;
-import kakao.festapick.festival.dto.FestivalDetailResponseDto;
-import kakao.festapick.festival.dto.FestivalListResponseForAdmin;
-import kakao.festapick.festival.dto.FestivalSearchCondForAdmin;
-import kakao.festapick.festival.dto.FestivalStateDto;
+import kakao.festapick.festival.dto.*;
 import kakao.festapick.festival.service.FestivalService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/kakao/festapick/festival/domain/Festival.java
+++ b/src/main/java/kakao/festapick/festival/domain/Festival.java
@@ -122,7 +122,7 @@ public class Festival {
     }
 
     private void checkStartAndEndDate(LocalDate startDate, LocalDate endDate) {
-        if (endDate.isBefore(startDate)) throw new BadRequestException(ExceptionCode.BAD_REQUEST,"시작일은 종료일보다 빨라야합니다.");
+        if (endDate.isBefore(startDate)) throw new BadRequestException(ExceptionCode.FESTIVAL_BAD_DATE);
     }
 
 }

--- a/src/main/java/kakao/festapick/festival/dto/FestivalCustomRequestDto.java
+++ b/src/main/java/kakao/festapick/festival/dto/FestivalCustomRequestDto.java
@@ -30,5 +30,4 @@ public record FestivalCustomRequestDto(
         @Length(min = 30, max = 5000)
         String overView
 ) {
-
 }

--- a/src/main/java/kakao/festapick/festival/service/FestivalService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalService.java
@@ -19,6 +19,7 @@ import kakao.festapick.festival.dto.FestivalUpdateRequestDto;
 import kakao.festapick.festival.repository.FestivalRepository;
 import kakao.festapick.festival.repository.QFestivalRepository;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
+import kakao.festapick.fileupload.service.S3Service;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.ForbiddenException;
 import kakao.festapick.global.exception.NotFoundEntityException;
@@ -26,6 +27,7 @@ import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class FestivalService {
     private final FestivalRepository festivalRepository;
     private final UserRepository userRepository;
     private final QFestivalRepository  qFestivalRepository;
+    private final S3Service s3Service;
 
     //CREATE
     //TODO: create - customized Festival (How to upload an image)
@@ -118,7 +121,12 @@ public class FestivalService {
 
     @Transactional
     public void deleteFestivalForAdmin(Long festivalId) {
+        Festival festival = festivalRepository.findFestivalById(festivalId)
+                .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.FESTIVAL_NOT_FOUND));
+
         festivalRepository.deleteById(festivalId);
+
+        s3Service.deleteS3File(festival.getImageUrl());
     }
 
     private String getHomePage(String homePage){

--- a/src/main/java/kakao/festapick/fileupload/controller/S3Controller.java
+++ b/src/main/java/kakao/festapick/fileupload/controller/S3Controller.java
@@ -1,0 +1,37 @@
+package kakao.festapick.fileupload.controller;
+
+import jakarta.validation.Valid;
+import kakao.festapick.fileupload.dto.S3FileDeleteRequest;
+import kakao.festapick.fileupload.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/presigned-url")
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    // Presigned URL 발급받기
+    @PostMapping
+    public ResponseEntity<Map<String, String>> getPresignedURL() {
+        String uploadPresignedURL = s3Service.createUploadPresignedURL();
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("presignedUrl",uploadPresignedURL));
+    }
+
+    // 파일 삭제 (업로드 취소할 경우 꼭 호출해줘야함)
+    @DeleteMapping
+    public ResponseEntity<Void> deleteS3File(@Valid @RequestBody S3FileDeleteRequest s3FileDeleteRequest) {
+
+        s3Service.deleteFiles(s3FileDeleteRequest);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+}

--- a/src/main/java/kakao/festapick/fileupload/controller/S3Controller.java
+++ b/src/main/java/kakao/festapick/fileupload/controller/S3Controller.java
@@ -18,15 +18,15 @@ public class S3Controller {
     private final S3Service s3Service;
 
     // Presigned URL 발급받기
-    @PostMapping
+    @GetMapping
     public ResponseEntity<Map<String, String>> getPresignedURL() {
         String uploadPresignedURL = s3Service.createUploadPresignedURL();
 
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("presignedUrl",uploadPresignedURL));
     }
 
-    // 파일 삭제 (업로드 취소할 경우 꼭 호출해줘야함)
-    @DeleteMapping
+    // 파일 다건 삭제 (업로드 취소할 경우 꼭 호출해줘야함)
+    @PostMapping("/delete")
     public ResponseEntity<Void> deleteS3File(@Valid @RequestBody S3FileDeleteRequest s3FileDeleteRequest) {
 
         s3Service.deleteFiles(s3FileDeleteRequest);

--- a/src/main/java/kakao/festapick/fileupload/domain/DomainType.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/DomainType.java
@@ -1,0 +1,5 @@
+package kakao.festapick.fileupload.domain;
+
+public enum DomainType {
+    REVIEW
+}

--- a/src/main/java/kakao/festapick/fileupload/domain/FileEntity.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/FileEntity.java
@@ -1,0 +1,40 @@
+package kakao.festapick.fileupload.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FileEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "file_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private FileType fileType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DomainType domainType;
+
+    @Column(nullable = false)
+    private Long domainId;
+
+    public FileEntity(String url, FileType fileType, DomainType domainType, Long domainId) {
+        this.url = url;
+        this.fileType = fileType;
+        this.domainType = domainType;
+        this.domainId = domainId;
+    }
+}

--- a/src/main/java/kakao/festapick/fileupload/domain/FileType.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/FileType.java
@@ -1,0 +1,5 @@
+package kakao.festapick.fileupload.domain;
+
+public enum FileType {
+    IMAGE, VIDEO
+}

--- a/src/main/java/kakao/festapick/fileupload/dto/S3FileDeleteRequest.java
+++ b/src/main/java/kakao/festapick/fileupload/dto/S3FileDeleteRequest.java
@@ -1,0 +1,10 @@
+package kakao.festapick.fileupload.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record S3FileDeleteRequest(
+        @NotNull
+        List<String> presignedUrls
+) {
+}

--- a/src/main/java/kakao/festapick/fileupload/repository/FileRepository.java
+++ b/src/main/java/kakao/festapick/fileupload/repository/FileRepository.java
@@ -1,0 +1,22 @@
+package kakao.festapick.fileupload.repository;
+
+import kakao.festapick.fileupload.domain.DomainType;
+import kakao.festapick.fileupload.domain.FileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface FileRepository extends JpaRepository<FileEntity, Long> { ;
+
+    @Query("select f from FileEntity f where f.domainId in (:domainIds) and f.domainType = :domainType")
+    List<FileEntity> findByDomainIdsAndDomainType(List<Long> domainIds, DomainType domainType);
+
+    @Query("select f from FileEntity f where f.domainId = :domainId and f.domainType = :domainType")
+    List<FileEntity> findByDomainIdAndDomainType(Long domainId, DomainType domainType);
+
+    @Modifying
+    @Query("delete from FileEntity f where f.domainId = :domainId and f.domainType = :domainType ")
+    void deleteByDomainAndDomainType(Long domainId, DomainType domainType);
+}

--- a/src/main/java/kakao/festapick/fileupload/service/FileService.java
+++ b/src/main/java/kakao/festapick/fileupload/service/FileService.java
@@ -1,0 +1,47 @@
+package kakao.festapick.fileupload.service;
+
+import kakao.festapick.fileupload.domain.DomainType;
+import kakao.festapick.fileupload.domain.FileEntity;
+import kakao.festapick.fileupload.domain.FileType;
+import kakao.festapick.fileupload.dto.S3FileDeleteRequest;
+import kakao.festapick.fileupload.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final FileRepository fileRepository;
+    private final S3Service s3Service;
+
+
+    public void saveAll(List<FileEntity> files) {
+        fileRepository.saveAll(files);
+    }
+
+    public List<FileEntity> findAllFileEntityByDomain(List<Long> domainIds, DomainType domainType) {
+
+       return fileRepository.findByDomainIdsAndDomainType(domainIds, domainType);
+    }
+
+    public List<FileEntity> findByDomainIdAndDomainType(Long domainId, DomainType domainType) {
+        return fileRepository.findByDomainIdAndDomainType(domainId, domainType);
+    }
+
+    public void deleteByDomainId(Long domainId, DomainType domainType) {
+
+        List<String> urls = fileRepository.findByDomainIdAndDomainType(domainId, domainType)
+                .stream()
+                .map(FileEntity::getUrl).toList();
+
+        s3Service.deleteFiles(new S3FileDeleteRequest(urls));
+
+        fileRepository.deleteByDomainAndDomainType(domainId,domainType);
+    }
+
+}

--- a/src/main/java/kakao/festapick/fileupload/service/S3Service.java
+++ b/src/main/java/kakao/festapick/fileupload/service/S3Service.java
@@ -47,8 +47,9 @@ public class S3Service {
                 .forEach(this::deleteS3File);
     }
 
-    private void deleteS3File(String imageURL) {
+    public void deleteS3File(String imageURL) {
         String path = extractFileName(imageURL);
+        if (path.startsWith("defaultImage")) return;
 
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                 .bucket(bucketName)

--- a/src/main/java/kakao/festapick/fileupload/service/S3Service.java
+++ b/src/main/java/kakao/festapick/fileupload/service/S3Service.java
@@ -61,6 +61,6 @@ public class S3Service {
 
     private String extractFileName(String imageURL) {
         int idx = imageURL.indexOf(".amazonaws.com/") + ".amazonaws.com/".length();
-        return imageURL.substring(idx, idx+36);
+        return imageURL.substring(idx);
     }
 }

--- a/src/main/java/kakao/festapick/fileupload/service/S3Service.java
+++ b/src/main/java/kakao/festapick/fileupload/service/S3Service.java
@@ -1,0 +1,65 @@
+package kakao.festapick.fileupload.service;
+
+import kakao.festapick.fileupload.dto.S3FileDeleteRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    public String createUploadPresignedURL() {
+
+        String filePath = UUID.randomUUID().toString();
+
+        PutObjectRequest uploadRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(filePath)
+                .build();
+
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(
+                r -> r.putObjectRequest(uploadRequest)
+                        .signatureDuration(Duration.ofMinutes(5))
+        );
+
+        return presignedPutObjectRequest.url().toString();
+    }
+
+    public void deleteFiles(S3FileDeleteRequest s3FileDeleteRequest) {
+        s3FileDeleteRequest.presignedUrls()
+                .forEach(this::deleteS3File);
+    }
+
+    private void deleteS3File(String imageURL) {
+        String path = extractFileName(imageURL);
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(path)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
+    private String extractFileName(String imageURL) {
+        int idx = imageURL.indexOf(".amazonaws.com/") + ".amazonaws.com/".length();
+        return imageURL.substring(idx, idx+36);
+    }
+}

--- a/src/main/java/kakao/festapick/fileupload/service/S3Service.java
+++ b/src/main/java/kakao/festapick/fileupload/service/S3Service.java
@@ -60,7 +60,9 @@ public class S3Service {
     }
 
     private String extractFileName(String imageURL) {
-        int idx = imageURL.indexOf(".amazonaws.com/") + ".amazonaws.com/".length();
-        return imageURL.substring(idx);
+        int pathStartIdx = imageURL.indexOf(".amazonaws.com/") + ".amazonaws.com/".length();
+        int pathEndIdx = imageURL.contains("?") ? imageURL.indexOf("?") : imageURL.length();
+
+        return imageURL.substring(pathStartIdx, pathEndIdx);
     }
 }

--- a/src/main/java/kakao/festapick/global/GlobalExceptionHandler.java
+++ b/src/main/java/kakao/festapick/global/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package kakao.festapick.global;
 
 import kakao.festapick.global.exception.AuthenticationException;
+import kakao.festapick.global.exception.BadRequestException;
 import kakao.festapick.global.exception.DuplicateEntityException;
 import kakao.festapick.global.exception.NotFoundEntityException;
 import lombok.extern.slf4j.Slf4j;
@@ -61,4 +62,10 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("globalErrors", globalErrors, "fieldErrors", fieldErrors));
     }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Map<String,String>> handleBadRequestException(BadRequestException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", e.getMessage()));
+    }
+
 }

--- a/src/main/java/kakao/festapick/global/exception/BadRequestException.java
+++ b/src/main/java/kakao/festapick/global/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package kakao.festapick.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BadRequestException extends RuntimeException {
+  private final ExceptionCode exceptionCode;
+
+  public BadRequestException(ExceptionCode exceptionCode, String errorMessage) {
+    super(exceptionCode.getErrorMessage() + " : " + errorMessage);
+    this.exceptionCode = exceptionCode;
+  }
+}

--- a/src/main/java/kakao/festapick/global/exception/BadRequestException.java
+++ b/src/main/java/kakao/festapick/global/exception/BadRequestException.java
@@ -3,13 +3,13 @@ package kakao.festapick.global.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Getter
 public class BadRequestException extends RuntimeException {
+
   private final ExceptionCode exceptionCode;
 
-  public BadRequestException(ExceptionCode exceptionCode, String errorMessage) {
-    super(exceptionCode.getErrorMessage() + " : " + errorMessage);
-    this.exceptionCode = exceptionCode;
-  }
+    public BadRequestException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getErrorMessage());
+        this.exceptionCode = exceptionCode;
+    }
 }

--- a/src/main/java/kakao/festapick/global/exception/DuplicateEntityException.java
+++ b/src/main/java/kakao/festapick/global/exception/DuplicateEntityException.java
@@ -4,8 +4,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class DuplicateEntityException extends RuntimeException {
 
     private final ExceptionCode exceptionCode;
+
+    public DuplicateEntityException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getErrorMessage());
+        this.exceptionCode = exceptionCode;
+    }
 }

--- a/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
+++ b/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
@@ -26,7 +26,7 @@ public enum ExceptionCode {
     FESTIVAL_ACCESS_FORBIDDEN("내가 등록한 축제가 아닙니다."),
 
     //BAD_REQUEST
-    BAD_REQUEST("잘못된 요청입니다.");
+    FESTIVAL_BAD_DATE("축제 시작일은 종료일보다 빨라야합니다.");
 
     private final String errorMessage;
 

--- a/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
+++ b/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
@@ -23,7 +23,10 @@ public enum ExceptionCode {
     REVIEW_DUPLICATE("이미 리뷰를 한 축제입니다, 리뷰 수정을 이용해주세요."),
   
     //FORBIDDEN
-    FESTIVAL_ACCESS_FORBIDDEN("내가 등록한 축제가 아닙니다.");
+    FESTIVAL_ACCESS_FORBIDDEN("내가 등록한 축제가 아닙니다."),
+
+    //BAD_REQUEST
+    BAD_REQUEST("잘못된 요청입니다.");
 
     private final String errorMessage;
 

--- a/src/main/java/kakao/festapick/global/exception/ForbiddenException.java
+++ b/src/main/java/kakao/festapick/global/exception/ForbiddenException.java
@@ -4,10 +4,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class ForbiddenException extends RuntimeException {
 
     private final ExceptionCode exceptionCode;
 
+    public ForbiddenException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getErrorMessage());
+        this.exceptionCode = exceptionCode;
+    }
 }
 

--- a/src/main/java/kakao/festapick/global/exception/NotFoundEntityException.java
+++ b/src/main/java/kakao/festapick/global/exception/NotFoundEntityException.java
@@ -4,9 +4,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class NotFoundEntityException extends RuntimeException {
 
     private final ExceptionCode exceptionCode;
 
+    public NotFoundEntityException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getErrorMessage());
+        this.exceptionCode = exceptionCode;
+    }
 }

--- a/src/main/java/kakao/festapick/review/domain/Review.java
+++ b/src/main/java/kakao/festapick/review/domain/Review.java
@@ -1,13 +1,6 @@
 package kakao.festapick.review.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/kakao/festapick/review/dto/ReviewRequestDto.java
+++ b/src/main/java/kakao/festapick/review/dto/ReviewRequestDto.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public record ReviewRequestDto(
         @NotBlank(message = "내용을 입력해 주세요")
         @Size(min = 10, max= 500, message = "리뷰는 10자 이상, 500자 이내로 작성할 수 있습니다")
@@ -13,7 +15,9 @@ public record ReviewRequestDto(
         @NotNull
         @Min(value = 1, message = "점수는 최소 1점에서 최대 5점 까지 가능합니다")
         @Max(value = 5, message = "점수는 최소 1점에서 최대 5점 까지 가능합니다")
-        Integer score
+        Integer score,
+        List<String> imageUrls,
+        String videoUrl // 일단 video url은 한개만 제한
 ) {
 
 }

--- a/src/main/java/kakao/festapick/review/dto/ReviewResponseDto.java
+++ b/src/main/java/kakao/festapick/review/dto/ReviewResponseDto.java
@@ -2,16 +2,22 @@ package kakao.festapick.review.dto;
 
 import kakao.festapick.review.domain.Review;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public record ReviewResponseDto (
         Long reviewId,
         String reviewerName,
         String festivalTitle,
         String content,
-        Integer score
+        Integer score,
+        List<String> imageUrls,
+        String videoUrl
+
 ) {
 
-    public ReviewResponseDto(Review review) {
+    public ReviewResponseDto(Review review, List<String> imageUrls, String videoUrl) {
         this(review.getId(), review.getReviewerName(), review.getFestivalTitle(),
-                review.getContent(), review.getScore());
+                review.getContent(), review.getScore(), imageUrls, videoUrl);
     }
 }

--- a/src/main/java/kakao/festapick/review/service/ReviewService.java
+++ b/src/main/java/kakao/festapick/review/service/ReviewService.java
@@ -3,6 +3,10 @@ package kakao.festapick.review.service;
 import jakarta.validation.Valid;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.repository.FestivalRepository;
+import kakao.festapick.fileupload.domain.DomainType;
+import kakao.festapick.fileupload.domain.FileEntity;
+import kakao.festapick.fileupload.domain.FileType;
+import kakao.festapick.fileupload.service.FileService;
 import kakao.festapick.global.exception.DuplicateEntityException;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
@@ -18,17 +22,22 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final OAuth2UserService oAuth2UserService;
     private final FestivalRepository festivalRepository;
+    private final FileService fileService;
 
-    @Transactional
-    public ReviewResponseDto createReview(Long festivalId, @Valid ReviewRequestDto requestDto, String identifier) {
+
+    public Long createReview(Long festivalId, @Valid ReviewRequestDto requestDto, String identifier) {
         Festival festival = festivalRepository.findFestivalById(festivalId)
                 .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.FESTIVAL_NOT_FOUND));
         UserEntity user = oAuth2UserService.findByIdentifier(identifier);
@@ -40,34 +49,113 @@ public class ReviewService {
         Review newReview = new Review(user, festival, requestDto.content(), requestDto.score());
         Review saved = reviewRepository.save(newReview);
 
-        return new ReviewResponseDto(saved);
+        saveFiles(requestDto, saved);
+
+        return saved.getId();
     }
 
     public Page<ReviewResponseDto> getFestivalReviews(Long festivalId, Pageable pageable) {
         Page<Review> reviews = reviewRepository.findByFestivalIdWithAll(festivalId, pageable);
-        return reviews.map(review -> new ReviewResponseDto(review));
+
+        List<FileEntity> files = findFilesByReview(reviews);
+
+        HashMap<Long, List<String>> imageUrls = new HashMap<>();
+        HashMap<Long, String> videoUrl = new HashMap<>();
+
+        reviewIdAndUrlMapping(files, imageUrls, videoUrl);
+
+
+        return reviews.map(review->
+                new ReviewResponseDto(review, imageUrls.getOrDefault(review.getId(), List.of()), videoUrl.get(review.getId()))
+        );
+    }
+
+    public ReviewResponseDto getReview(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.REVIEW_NOT_FOUND));
+
+        List<FileEntity> files = fileService.findByDomainIdAndDomainType(reviewId, DomainType.REVIEW);
+
+        HashMap<Long, List<String>> imageUrls = new HashMap<>();
+        HashMap<Long, String> videoUrl = new HashMap<>();
+
+        reviewIdAndUrlMapping(files, imageUrls, videoUrl);
+
+        return new ReviewResponseDto(review, imageUrls.get(reviewId), videoUrl.get(reviewId));
+
     }
 
     public Page<ReviewResponseDto> getMyReviews(String identifier, Pageable pageable) {
         Page<Review> reviews = reviewRepository.findByUserIdentifierWithAll(identifier, pageable);
-        return reviews.map(review -> new ReviewResponseDto(review));
+
+
+        List<FileEntity> files = findFilesByReview(reviews);
+
+        HashMap<Long, List<String>> imageUrls = new HashMap<>();
+        HashMap<Long, String> videoUrl = new HashMap<>();
+
+        reviewIdAndUrlMapping(files, imageUrls, videoUrl);
+
+
+        return reviews.map(review -> new ReviewResponseDto(review, imageUrls.get(review.getId()), videoUrl.get(review.getId())));
     }
 
-    @Transactional
-    public ReviewResponseDto updateReview(Long reviewId, @Valid ReviewRequestDto requestDto, String identifier) {
+
+    public void updateReview(Long reviewId, @Valid ReviewRequestDto requestDto, String identifier) {
         Review review = reviewRepository.findByUserIdentifierAndId(identifier, reviewId)
                 .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.REVIEW_NOT_FOUND));
 
         review.changeContent(requestDto.content());
         review.changeScore(requestDto.score());
 
-        return new ReviewResponseDto(review);
+        fileService.deleteByDomainId(reviewId, DomainType.REVIEW);
+
+        saveFiles(requestDto, review);
+
     }
 
-    @Transactional
+
     public void removeReview(Long reviewId, String identifier) {
+
         if (reviewRepository.deleteByUserIdentifierAndId(identifier, reviewId) == 0) {
             throw new NotFoundEntityException(ExceptionCode.REVIEW_NOT_FOUND);
         }
+
+        fileService.deleteByDomainId(reviewId, DomainType.REVIEW);
+    }
+
+    private void saveFiles(ReviewRequestDto requestDto, Review saved) {
+        List<FileEntity> files = new ArrayList<>();
+
+        if(requestDto.imageUrls() != null) requestDto.imageUrls().forEach(url ->
+                files.add(new FileEntity(url, FileType.IMAGE, DomainType.REVIEW, saved.getId())));
+
+        if (requestDto.videoUrl() != null && !requestDto.videoUrl().isBlank())
+            files.add(new FileEntity(requestDto.videoUrl(), FileType.VIDEO, DomainType.REVIEW, saved.getId()));
+
+
+        if (!files.isEmpty()) fileService.saveAll(files);
+    }
+
+    // 리뷰와 관련된 파일 가져오기 - 쿼리 1개
+    private List<FileEntity> findFilesByReview(Page<Review> reviews) {
+        List<Long> domainIds = reviews.stream()
+                .map(Review::getId)
+                .toList();
+
+        return fileService.findAllFileEntityByDomain(domainIds, DomainType.REVIEW);
+    }
+
+    // reviewId와 url을 매핑
+    private static void reviewIdAndUrlMapping(List<FileEntity> files, HashMap<Long, List<String>> imageUrls, HashMap<Long, String> videoUrl) {
+        files.forEach(file-> {
+            if (file.getFileType().equals(FileType.IMAGE)) {
+                if (!imageUrls.containsKey(file.getDomainId())) imageUrls.put(file.getDomainId(), new ArrayList<>());
+                imageUrls.get(file.getDomainId()).add(file.getUrl());
+            }
+            else {
+                videoUrl.put(file.getDomainId(), file.getUrl());
+            }
+        });
     }
 }

--- a/src/main/java/kakao/festapick/user/controller/UserAdminController.java
+++ b/src/main/java/kakao/festapick/user/controller/UserAdminController.java
@@ -2,7 +2,7 @@ package kakao.festapick.user.controller;
 
 import kakao.festapick.user.dto.UserSearchCond;
 import kakao.festapick.user.domain.UserRoleType;
-import kakao.festapick.user.dto.UserResponseDto;
+import kakao.festapick.user.dto.UserResponseDtoForAdmin;
 import kakao.festapick.user.service.OAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -38,7 +38,7 @@ public class UserAdminController {
                                      Model model) {
 
 
-        Page<UserResponseDto> response = oAuth2UserService.findByIdentifierOrUserEmail(new UserSearchCond(identifier,email, role), pageable);
+        Page<UserResponseDtoForAdmin> response = oAuth2UserService.findByIdentifierOrUserEmail(new UserSearchCond(identifier,email, role), pageable);
 
         model.addAttribute("pageData", response);
         model.addAttribute("identifier", identifier);

--- a/src/main/java/kakao/festapick/user/controller/UserController.java
+++ b/src/main/java/kakao/festapick/user/controller/UserController.java
@@ -1,14 +1,15 @@
 package kakao.festapick.user.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import kakao.festapick.user.dto.ProfileImageUpdateRequest;
+import kakao.festapick.user.dto.UserResponseDto;
 import kakao.festapick.user.service.OAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -24,6 +25,23 @@ public class UserController {
         oAuth2UserService.withDraw(identifier,response);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PatchMapping("/profileImage") // 프로필 이미지 변경
+    public ResponseEntity<Void> changeProfileImage(@Valid @RequestBody ProfileImageUpdateRequest profileImageUpdateRequest,
+                                                   @AuthenticationPrincipal String identifier) {
+
+        oAuth2UserService.changeProfileImage(identifier, profileImageUpdateRequest.imageUrl());
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @GetMapping // 본인 정보 조회
+    public ResponseEntity<UserResponseDto> getMyInfo(@AuthenticationPrincipal String identifier) {
+
+        UserResponseDto response = oAuth2UserService.findMyInfo(identifier);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 }

--- a/src/main/java/kakao/festapick/user/domain/UserEntity.java
+++ b/src/main/java/kakao/festapick/user/domain/UserEntity.java
@@ -21,6 +21,9 @@ import java.util.List;
 @Getter
 public class UserEntity {
 
+    private static final String defaultImage
+            = "https://festapick-file.s3.ap-northeast-2.amazonaws.com/defaultImage/userDefaultImage.jpeg";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -43,6 +46,9 @@ public class UserEntity {
     @Column(nullable = false)
     private SocialType socialType;
 
+    @Column(nullable = false)
+    private String profileImageUrl;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefreshToken> refreshToken;
 
@@ -59,6 +65,7 @@ public class UserEntity {
         this.username = username;
         this.roleType = userRoleType;
         this.socialType = socialType;
+        this.profileImageUrl = defaultImage;
     }
 
     public UserEntity(Long id, String identifier, String email, String username, UserRoleType roleType, SocialType socialType) {
@@ -68,9 +75,14 @@ public class UserEntity {
         this.username = username;
         this.roleType = roleType;
         this.socialType = socialType;
+        this.profileImageUrl = defaultImage;
     }
 
     public void changeUserRole(UserRoleType roleType) {
         this.roleType = roleType;
+    }
+
+    public void changeProfileImage(String imageUrl) {
+        this.profileImageUrl = imageUrl;
     }
 }

--- a/src/main/java/kakao/festapick/user/dto/ProfileImageUpdateRequest.java
+++ b/src/main/java/kakao/festapick/user/dto/ProfileImageUpdateRequest.java
@@ -1,0 +1,9 @@
+package kakao.festapick.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProfileImageUpdateRequest(
+        @NotBlank
+        String imageUrl
+) {
+}

--- a/src/main/java/kakao/festapick/user/dto/UserResponseDto.java
+++ b/src/main/java/kakao/festapick/user/dto/UserResponseDto.java
@@ -3,14 +3,12 @@ package kakao.festapick.user.dto;
 import kakao.festapick.user.domain.UserEntity;
 
 public record UserResponseDto(
-        Long id,
         String email,
-        String identifier,
         String username,
-        String role
+        String profileImageUrl
 ) {
+
     public UserResponseDto(UserEntity userEntity) {
-        this(userEntity.getId(), userEntity.getEmail(),
-                userEntity.getIdentifier(), userEntity.getUsername(), userEntity.getRoleType().name());
+        this(userEntity.getEmail(), userEntity.getUsername(), userEntity.getProfileImageUrl());
     }
 }

--- a/src/main/java/kakao/festapick/user/dto/UserResponseDtoForAdmin.java
+++ b/src/main/java/kakao/festapick/user/dto/UserResponseDtoForAdmin.java
@@ -1,0 +1,16 @@
+package kakao.festapick.user.dto;
+
+import kakao.festapick.user.domain.UserEntity;
+
+public record UserResponseDtoForAdmin(
+        Long id,
+        String email,
+        String identifier,
+        String username,
+        String role
+) {
+    public UserResponseDtoForAdmin(UserEntity userEntity) {
+        this(userEntity.getId(), userEntity.getEmail(),
+                userEntity.getIdentifier(), userEntity.getUsername(), userEntity.getRoleType().name());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,3 +61,9 @@ spring.secretBase64=${SECRET_BASE64}
 
 #TOUR-API
 tour.api.secret.key=${TOUR_API_KEY}
+
+# aws s3
+aws.credentials.access-key=${AWS_ACCESS}
+aws.credentials.secret-key=${AWS_SECRET}
+aws.s3.region=ap-northeast-2
+aws.s3.bucket=festapick-file

--- a/src/test/java/kakao/festapick/festival/domain/FestivalTest.java
+++ b/src/test/java/kakao/festapick/festival/domain/FestivalTest.java
@@ -4,7 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
+
+import kakao.festapick.festival.dto.FestivalCustomRequestDto;
+import kakao.festapick.festival.dto.FestivalRequestDto;
 import kakao.festapick.festival.dto.FestivalUpdateRequestDto;
+import kakao.festapick.user.domain.SocialType;
+import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.domain.UserRoleType;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class FestivalTest {
@@ -38,6 +45,18 @@ class FestivalTest {
 
         //then
         assertThat(festival.getState()).isEqualTo(festivalState);
+    }
+
+    @Test
+    @DisplayName("이미지 url이 빈값일때, 기본 이미지 반환")
+    void returnDefaultImage() {
+        FestivalCustomRequestDto festivalCustomRequestDto = new FestivalCustomRequestDto("축제title", 32, "주소1", "상세주소",
+                "", LocalDate.of(2025, 8, 24), LocalDate.of(2025, 8, 25), "hompage", "overivew");
+
+        Festival festival = new Festival(festivalCustomRequestDto, new UserEntity("GOOGLE-1234",
+                "example@gmail.com", "exampleName", UserRoleType.USER, SocialType.GOOGLE));
+
+        assertThat(festival.getImageUrl()).isNotBlank();
     }
 
     private Festival createFestival(){

--- a/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
+++ b/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
@@ -137,7 +137,7 @@ class FestivalServiceTest {
         assertThatThrownBy(()->
                 festivalService.addCustomizedFestival(requestDto, user.getIdentifier()))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining(ExceptionCode.BAD_REQUEST.getErrorMessage());
+                .hasMessage(ExceptionCode.FESTIVAL_BAD_DATE.getErrorMessage());
 
         verify(userRepository).findByIdentifier(any());
         verifyNoMoreInteractions(userRepository);

--- a/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
+++ b/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
@@ -1,22 +1,29 @@
 package kakao.festapick.user.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kakao.festapick.mockuser.WithCustomMockUser;
 import kakao.festapick.user.domain.SocialType;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.domain.UserRoleType;
+import kakao.festapick.user.dto.ProfileImageUpdateRequest;
+import kakao.festapick.user.dto.UserResponseDto;
 import kakao.festapick.user.repository.UserRepository;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -30,6 +37,9 @@ class UserControllerTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private static final String identifier = "GOOGLE_1234";
 
@@ -48,6 +58,53 @@ class UserControllerTest {
         Optional<UserEntity> findUser = userRepository.findById(userEntity.getId());
 
         assertThat(findUser.isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("본인 정보 조회 성공")
+    @WithCustomMockUser(identifier = identifier, role = "ROLE_USER")
+    void getMyInfoSuccess() throws Exception {
+
+        // given
+        UserEntity userEntity = saveUserEntity();
+
+        // when
+        String response = mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        // then
+        UserResponseDto userResponseDto = objectMapper.readValue(response, UserResponseDto.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(userResponseDto.email()).isEqualTo(userEntity.getEmail());
+            softly.assertThat(userResponseDto.profileImageUrl()).isEqualTo(userEntity.getProfileImageUrl());
+            softly.assertThat(userResponseDto.username()).isEqualTo(userEntity.getUsername());
+        });
+
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업데이트 성공")
+    @WithCustomMockUser(identifier = identifier, role = "ROLE_USER")
+    void changeProfileImageSuccess() throws Exception {
+
+        // given
+        UserEntity userEntity = saveUserEntity();
+
+        ProfileImageUpdateRequest updateImageUrl = new ProfileImageUpdateRequest("updateImageUrl");
+
+        String request = objectMapper.writeValueAsString(updateImageUrl);
+
+        // when
+        mockMvc.perform(patch("/api/users/profileImage")
+                        .content(request)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        UserEntity findUser = userRepository.findById(userEntity.getId()).get();
+
+        assertThat(findUser.getProfileImageUrl()).isEqualTo(updateImageUrl.imageUrl());
     }
 
     private UserEntity saveUserEntity() {

--- a/src/test/java/kakao/festapick/user/service/OAuth2UserServiceTest.java
+++ b/src/test/java/kakao/festapick/user/service/OAuth2UserServiceTest.java
@@ -1,11 +1,15 @@
 package kakao.festapick.user.service;
 
 
+import kakao.festapick.fileupload.service.S3Service;
 import kakao.festapick.global.component.CookieComponent;
+import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.user.domain.SocialType;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.domain.UserRoleType;
 import kakao.festapick.user.dto.GoogleOAuth2Rep;
 import kakao.festapick.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.mockito.BDDMockito.*;
 
@@ -31,6 +36,9 @@ class OAuth2UserServiceTest {
 
     @Mock
     private CookieComponent cookieComponent;
+
+    @Mock
+    private S3Service s3Service;
 
 
     @Test
@@ -101,6 +109,45 @@ class OAuth2UserServiceTest {
         verify(userRepository).findByIdentifier(anyString());
         verifyNoMoreInteractions(userRepository);
         verifyNoMoreInteractions(cookieComponent);
+
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변환 성공")
+    void profileImageChangeSuccess() {
+
+        // given
+        UserEntity userEntity = new UserEntity("GOOGLE-1234",
+                "example@gmail.com", "exampleName", UserRoleType.USER, SocialType.GOOGLE);
+
+        given(userRepository.findByIdentifier(any()))
+                .willReturn(Optional.of(userEntity));
+
+        // when
+        oAuth2UserService.changeProfileImage(userEntity.getIdentifier(), "updateImageUrl");
+
+        // then
+        verify(userRepository).findByIdentifier(any());
+        verify(s3Service).deleteS3File(any());
+        verifyNoMoreInteractions(userRepository,s3Service);
+
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변환 실패 - 존재하지 않는 회원")
+    void profileImageChangeFail() {
+
+        // given
+
+        given(userRepository.findByIdentifier(any()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(()->
+                oAuth2UserService.changeProfileImage("GOOGLE-1234", "updateImageUrl")
+        ).isInstanceOf(NotFoundEntityException.class);
+        verify(userRepository).findByIdentifier(any());
+        verifyNoMoreInteractions(userRepository,s3Service);
 
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -63,3 +63,9 @@ spring.secretBase64=${SECRET_BASE64}
 
 #TOUR-API
 tour.api.secret.key=${TOUR_API_KEY}
+
+# aws s3
+aws.credentials.access-key=${AWS_ACCESS}
+aws.credentials.secret-key=${AWS_SECRET}
+aws.s3.region=ap-northeast-2
+aws.s3.bucket=festapick-file


### PR DESCRIPTION
`S3`의 `PresignedUrl`을 사용한 파일 업로드를 구현했습니다.

흐름은 이렇습니다.

1. 프론트엔드에서 `GET` `/api/presigned-url` 를 통해 `PresignedUrl`을 발급받습니다.
2. 발급받은 `PresignedUrl`을 통해서 파일 업로드를 합니다.
3. `PresignedUrl`을 그대로 `<img src>`에 사용하면 됩니다.
4. 파일 저장 관련한 리뷰,축제,사용자와 관련한 등록,수정이 일어날때 해당 `PresignedUrl`를 꼭 백엔드에 넘겨줘야합니다.
5. 만약 사용자가 업로드를 취소할 경우 쓸데없는 이미지가 S3 버킷에 남기때문에 `POST` `/api/presigned-url/delete`를 호출해줘야합니다

## 리뷰

리뷰는 다중 이미지 업로드, 단일 동영상 업로드로 구현했습니다.

다중 업로드이기 때문에 `FileEntity` 도메인을 만들었습니다.

## 축제

축제는 현재 포스터 사진 1개를 저장하는 것으로 합의했기때문에 축제 도메인 필드 자체에 imageUrl을 저장합니다.

사용자가 축제 포스터를 입력하지 않았을 경우에는 기본 이미지를 저장합니다.

## 사용자

사용자는 프로필 사진 1개를 저장하는 것으로 합의했기때문에 사용자 도메인 필드 자체에 imageUrl을 저장합니다.

사용자가 회원가입했을 경우에는 기본 프로필 이미지를 저장합니다.

`PATCH` `/api/users/profileImage` 를 통해 프로필 이미지를 변경할 수 있습니다.

## 고도화해야할 것

1. 사용자가 파일을 업로드하고 저장버튼을 누르지 않고 아예 화면을 꺼버리는 일이 발생할때는 S3에는 불필요한 파일들이 남습니다. 이 부분을 어떻게 해결해야할지 같이 생각해봐야할 것 같습니다.
2. 윤재님이 축제관련해서 수정 중이신 것 같아서 아직 축제 포스터 이미지 수정에 대해서는 구현을 하지 않았습니다.
3. 동영상 스트리밍이 가능한 것은 현재까지 mp4파일로 확인되었습니다.
4. 코드가 꽤 복잡합니다. 다음 회의때 파일 업로드 관련해서 설명해 드리겠습니다.