### PR TITLE
CascadeType으로 인한 N+1 문제, FileEntity 미삭제 문제 해결

### DIFF
--- a/src/main/java/kakao/festapick/config/SecurityConfig.java
+++ b/src/main/java/kakao/festapick/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import kakao.festapick.jwt.service.JwtService;
 import kakao.festapick.oauth2.handler.SocialSuccessHandler;
 import kakao.festapick.user.domain.UserRoleType;
 import kakao.festapick.user.service.OAuth2UserService;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,7 +41,7 @@ public class SecurityConfig {
     private final JwtService jwtService;
     private final CookieComponent cookieComponent;
     private final OAuth2UserService oAuth2UserService;
-    private final UserService userService;
+    private final UserLowService userLowService;
     @Value("${spring.front.domain}")
     private String frontDomain;
     @Value("${spring.backend.domain}")
@@ -76,9 +77,9 @@ public class SecurityConfig {
         http.sessionManagement(session->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        http.addFilterBefore(new JwtFilter(jwtUtil,userService), LogoutFilter.class);
+        http.addFilterBefore(new JwtFilter(jwtUtil,userLowService), LogoutFilter.class);
 
-        http.addFilterBefore(new JwtFilterForAdminPage(jwtUtil,userService,cookieComponent), JwtFilter.class);
+        http.addFilterBefore(new JwtFilterForAdminPage(jwtUtil,userLowService,cookieComponent), JwtFilter.class);
 
         http.addFilterAt(new CustomLogoutFilter(jwtUtil, jwtService, cookieComponent), LogoutFilter.class);
         http.addFilterAfter(new CustomLogoutFilterForAdminPage(jwtUtil, cookieComponent),CustomLogoutFilter.class);

--- a/src/main/java/kakao/festapick/festival/controller/FestivalUserController.java
+++ b/src/main/java/kakao/festapick/festival/controller/FestivalUserController.java
@@ -94,7 +94,7 @@ public class FestivalUserController {
             @AuthenticationPrincipal String identifier,
             @PathVariable Long festivalId
     ){
-        festivalService.removeOne(identifier, festivalId);
+        festivalService.deleteFestivalForManager(identifier, festivalId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/kakao/festapick/festival/domain/Festival.java
+++ b/src/main/java/kakao/festapick/festival/domain/Festival.java
@@ -133,6 +133,26 @@ public class Festival {
         this.homePage = requestDto.homePage();
     }
 
+    public Festival(String title, int areaCode,
+                    String addr1, String addr2,
+                    String posterInfo, LocalDate startDate,
+                    LocalDate endDate, String overView,
+                    String homePage, FestivalState state,
+                    UserEntity manager, String contentId) {
+        this.title = title;
+        this.areaCode = areaCode;
+        this.addr1 = addr1;
+        this.addr2 = addr2;
+        this.posterInfo = posterInfo;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.overView = overView;
+        this.homePage = homePage;
+        this.state = state;
+        this.manager = manager;
+        this.contentId = contentId;
+    }
+
     //admin만 축제 권한 변경
     public void updateState(FestivalState festivalState){
         this.state = festivalState;

--- a/src/main/java/kakao/festapick/festival/domain/Festival.java
+++ b/src/main/java/kakao/festapick/festival/domain/Festival.java
@@ -78,12 +78,6 @@ public class Festival {
     @JoinColumn(name = "manager_id")
     private UserEntity manager;
 
-    @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Wish>  wishes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Review> reviews = new ArrayList<>();
-
     protected Festival() { }
 
     //TODO: contentId 규칙 만들기

--- a/src/main/java/kakao/festapick/festival/repository/FestivalRepository.java
+++ b/src/main/java/kakao/festapick/festival/repository/FestivalRepository.java
@@ -30,7 +30,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
     @Query("select f from Festival f where f.contentId in :contentIds")
     List<Festival> findFestivalsByContentIds(List<String> contentIds);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from Festival f where f.manager.id = :userId")
     void deleteByManagerId(Long userId);
 

--- a/src/main/java/kakao/festapick/festival/repository/FestivalRepository.java
+++ b/src/main/java/kakao/festapick/festival/repository/FestivalRepository.java
@@ -8,6 +8,7 @@ import kakao.festapick.festival.domain.FestivalState;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long> {
@@ -24,7 +25,13 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
     Page<Festival> findFestivalByManagerId(Long managerId, Pageable pageable);
 
+    List<Festival> findFestivalByManagerId(Long managerId);
+
     @Query("select f from Festival f where f.contentId in :contentIds")
     List<Festival> findFestivalsByContentIds(List<String> contentIds);
+
+    @Modifying
+    @Query("delete from Festival f where f.manager.id = :userId")
+    void deleteByManagerId(Long userId);
 
 }

--- a/src/main/java/kakao/festapick/festival/service/FestivalService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalService.java
@@ -29,6 +29,7 @@ import kakao.festapick.global.exception.BadRequestException;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.ForbiddenException;
 import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.review.domain.Review;
 import kakao.festapick.review.repository.ReviewRepository;
 import kakao.festapick.review.service.ReviewService;
 import kakao.festapick.user.domain.UserEntity;
@@ -205,6 +206,16 @@ public class FestivalService {
         festivalRepository.deleteById(festival.getId());
 
         fileService.deleteByDomainId(festival.getId(), DomainType.FESTIVAL);
+    }
+
+    @Transactional
+    public void deleteFestivalByManagerId(Long id) {
+        List<Long> festivalIds = festivalRepository.findFestivalByManagerId(id)
+                .stream().map(Festival::getId).toList();
+
+        festivalRepository.deleteByManagerId(id);
+
+        fileService.deleteByDomainIds(festivalIds, DomainType.REVIEW); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
     }
 
     //수정 권한을 확인하기 위한 메서드

--- a/src/main/java/kakao/festapick/fileupload/repository/FileRepository.java
+++ b/src/main/java/kakao/festapick/fileupload/repository/FileRepository.java
@@ -18,7 +18,11 @@ public interface FileRepository extends JpaRepository<FileEntity, Long> { ;
 
     @Modifying
     @Query("delete from FileEntity f where f.domainId = :domainId and f.domainType = :domainType ")
-    void deleteByDomainAndDomainType(Long domainId, DomainType domainType);
+    void deleteByDomainIdAndDomainType(Long domainId, DomainType domainType);
+
+    @Modifying
+    @Query("delete from FileEntity f where f.domainId in (:domainIds) and f.domainType = :domainType")
+    void deleteByDomainIdsAndDomainType(List<Long> domainIds, DomainType domainType);
 
     @Query("select f from FileEntity f where f.url in :urls")
     List<FileEntity> findByUrls(List<String> urls);

--- a/src/main/java/kakao/festapick/fileupload/service/FileService.java
+++ b/src/main/java/kakao/festapick/fileupload/service/FileService.java
@@ -43,9 +43,21 @@ public class FileService {
                 .stream()
                 .map(FileEntity::getUrl).toList();
 
-        fileRepository.deleteByDomainAndDomainType(domainId,domainType);
+        fileRepository.deleteByDomainIdAndDomainType(domainId,domainType);
 
         s3Service.deleteFiles(urls); // s3 파일 삭제는 항상 마지막에 호출
+    }
+
+    public void deleteByDomainIds(List<Long> domainIds, DomainType domainType) {
+
+        List<String> urls = fileRepository.findByDomainIdsAndDomainType(domainIds, domainType)
+                .stream()
+                .map(FileEntity::getUrl).toList();
+
+        fileRepository.deleteByDomainIdsAndDomainType(domainIds, domainType);
+
+        s3Service.deleteFiles(urls); // s3 파일 삭제는 항상 마지막에 호출
+
     }
 
     public void checkUniqueURL(List<String> imagesUrl){

--- a/src/main/java/kakao/festapick/global/filter/JwtFilter.java
+++ b/src/main/java/kakao/festapick/global/filter/JwtFilter.java
@@ -10,6 +10,7 @@ import kakao.festapick.jwt.util.JwtUtil;
 import kakao.festapick.jwt.util.TokenType;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.service.OAuth2UserService;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -27,7 +28,7 @@ import java.util.List;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final UserService userService;
+    private final UserLowService userLowService;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -62,7 +63,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String identifier = claims.get("identifier").toString();
 
         try {
-            UserEntity findUser = userService.findByIdentifier(identifier);
+            UserEntity findUser = userLowService.findByIdentifier(identifier);
             List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_"+findUser.getRoleType().name()));
             Authentication auth = new UsernamePasswordAuthenticationToken(identifier, null, authorities);
             SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/kakao/festapick/global/filter/JwtFilterForAdminPage.java
+++ b/src/main/java/kakao/festapick/global/filter/JwtFilterForAdminPage.java
@@ -12,6 +12,7 @@ import kakao.festapick.jwt.util.JwtUtil;
 import kakao.festapick.jwt.util.TokenType;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.service.OAuth2UserService;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -30,7 +31,7 @@ import java.util.List;
 public class JwtFilterForAdminPage extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final UserService userService;
+    private final UserLowService userLowService;
     private final CookieComponent cookieComponent;
 
     @Override
@@ -72,7 +73,7 @@ public class JwtFilterForAdminPage extends OncePerRequestFilter {
         String identifier = claims.get("identifier").toString();
 
         try {
-            UserEntity findUser = userService.findByIdentifier(identifier);
+            UserEntity findUser = userLowService.findByIdentifier(identifier);
             List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_"+findUser.getRoleType().name()));
             Authentication auth = new UsernamePasswordAuthenticationToken(identifier, null, authorities);
             SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/kakao/festapick/jwt/service/JwtService.java
+++ b/src/main/java/kakao/festapick/jwt/service/JwtService.java
@@ -13,6 +13,7 @@ import kakao.festapick.jwt.domain.RefreshToken;
 import kakao.festapick.jwt.repository.RefreshTokenRepository;
 import kakao.festapick.jwt.util.TokenType;
 import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -29,14 +30,14 @@ import java.util.Arrays;
 public class JwtService {
 
     private final RefreshTokenRepository refreshTokenRepository;
-    private final UserService userService;
+    private final UserLowService userLowService;
     private final JwtUtil jwtUtil;
     private final CookieComponent cookieComponent;
     private final HmacUtil tokenEncoder;
 
     public RefreshToken saveRefreshToken(String identifier, String refreshToken) {
 
-        UserEntity findUser = userService.findByIdentifier(identifier);
+        UserEntity findUser = userLowService.findByIdentifier(identifier);
 
         String encodedRefreshToken = tokenEncoder.encode(refreshToken);
 
@@ -83,7 +84,7 @@ public class JwtService {
     }
 
     public void deleteRefreshTokenByIdentifier(String identifier) {
-        UserEntity findUser = userService.findByIdentifier(identifier);
+        UserEntity findUser = userLowService.findByIdentifier(identifier);
         refreshTokenRepository.deleteByUser(findUser);
     }
 

--- a/src/main/java/kakao/festapick/review/repository/ReviewRepository.java
+++ b/src/main/java/kakao/festapick/review/repository/ReviewRepository.java
@@ -29,4 +29,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Modifying(clearAutomatically = true)
     @Query(value = "delete from Review r where r.user.identifier= :identifier and r.id= :reviewId")
     int deleteByUserIdentifierAndId(String identifier, Long reviewId);
+
+    @Modifying
+    @Query("delete from Review r where r.user.id = :userId")
+    void deleteByUserId(Long userId);
+
 }

--- a/src/main/java/kakao/festapick/review/repository/ReviewRepository.java
+++ b/src/main/java/kakao/festapick/review/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package kakao.festapick.review.repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import com.querydsl.core.Fetchable;
 import kakao.festapick.review.domain.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,14 +33,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query(value = "delete from Review r where r.user.identifier= :identifier and r.id= :reviewId")
     int deleteByUserIdentifierAndId(String identifier, Long reviewId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from Review r where r.user.id = :userId")
     void deleteByUserId(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from Review r where r.festival.id = :festivalId")
     void deleteByFestivalId(Long festivalId);
 
     @Query("select r from Review r where r.festival.id = :festivalId")
     List<Review> findByFestivalId(Long festivalId);
+
+    @Query("select r from Review r where r.user.id = :userId")
+    List<Review> findByUserId(Long userId);
 }

--- a/src/main/java/kakao/festapick/review/repository/ReviewRepository.java
+++ b/src/main/java/kakao/festapick/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package kakao.festapick.review.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kakao.festapick.review.domain.Review;
 import org.springframework.data.domain.Page;
@@ -34,4 +35,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("delete from Review r where r.user.id = :userId")
     void deleteByUserId(Long userId);
 
+    @Modifying
+    @Query("delete from Review r where r.festival.id = :festivalId")
+    void deleteByFestivalId(Long festivalId);
+
+    @Query("select r from Review r where r.festival.id = :festivalId")
+    List<Review> findByFestivalId(Long festivalId);
 }

--- a/src/main/java/kakao/festapick/review/service/ReviewService.java
+++ b/src/main/java/kakao/festapick/review/service/ReviewService.java
@@ -168,8 +168,19 @@ public class ReviewService {
             throw new NotFoundEntityException(ExceptionCode.REVIEW_NOT_FOUND);
         }
 
-        fileService.deleteByDomainId(reviewId, DomainType.REVIEW);
+        fileService.deleteByDomainId(reviewId, DomainType.REVIEW); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
     }
+
+    public void deleteReviewByFestivalId(Long festivalId) {
+
+        List<Long> reviewIds = reviewRepository.findByFestivalId(festivalId)
+                .stream().map(Review::getId).toList();
+
+        reviewRepository.deleteByFestivalId(festivalId);
+
+        fileService.deleteByDomainIds(reviewIds, DomainType.REVIEW); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
+    }
+
 
     //review의 id만 넘기는건 어떤지?
     private void saveFiles(List<FileUploadRequest> imageInfos, FileUploadRequest videoInfo, Long id) {

--- a/src/main/java/kakao/festapick/user/domain/UserEntity.java
+++ b/src/main/java/kakao/festapick/user/domain/UserEntity.java
@@ -55,15 +55,6 @@ public class UserEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private RefreshToken refreshToken;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Review> reviews = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Wish> wishes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "manager", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Festival> festivals = new ArrayList<>();
-
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdDate;

--- a/src/main/java/kakao/festapick/user/service/UserLowService.java
+++ b/src/main/java/kakao/festapick/user/service/UserLowService.java
@@ -1,0 +1,35 @@
+package kakao.festapick.user.service;
+
+import kakao.festapick.global.exception.ExceptionCode;
+import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class UserLowService {
+
+    private final UserRepository userRepository;
+
+    public UserEntity findByIdentifier(String identifier) {
+        return userRepository.findByIdentifier(identifier)
+                .orElseThrow(()->new NotFoundEntityException(ExceptionCode.USER_NOT_FOUND));
+    }
+
+    public void deleteByIdentifier(String identifier) {
+        userRepository.deleteByIdentifier(identifier);
+    }
+
+    public UserEntity findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(()->new NotFoundEntityException(ExceptionCode.USER_NOT_FOUND));
+    }
+
+    public void deleteById(Long id) {
+        userRepository.deleteById(id);
+    }
+}

--- a/src/main/java/kakao/festapick/user/service/UserService.java
+++ b/src/main/java/kakao/festapick/user/service/UserService.java
@@ -1,12 +1,14 @@
 package kakao.festapick.user.service;
 
 import jakarta.servlet.http.HttpServletResponse;
+import kakao.festapick.festival.repository.FestivalRepository;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 import kakao.festapick.fileupload.repository.TemporalFileRepository;
 import kakao.festapick.fileupload.service.S3Service;
 import kakao.festapick.global.component.CookieComponent;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.review.repository.ReviewRepository;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.domain.UserRoleType;
 import kakao.festapick.user.dto.UserResponseDto;
@@ -14,6 +16,7 @@ import kakao.festapick.user.dto.UserResponseDtoForAdmin;
 import kakao.festapick.user.dto.UserSearchCond;
 import kakao.festapick.user.repository.QUserRepository;
 import kakao.festapick.user.repository.UserRepository;
+import kakao.festapick.wish.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +29,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final FestivalRepository festivalRepository;
+    private final WishRepository wishRepository;
+    private final ReviewRepository reviewRepository;
     private final CookieComponent cookieComponent;
     private final QUserRepository qUserRepository;
     private final S3Service s3Service;
@@ -39,6 +45,10 @@ public class UserService {
     public void withDraw(String identifier, HttpServletResponse response) {
 
         UserEntity findUser = findByIdentifier(identifier);
+
+        festivalRepository.deleteByManagerId(findUser.getId());
+        wishRepository.deleteByUserId(findUser.getId());
+        reviewRepository.deleteByUserId(findUser.getId());
 
         userRepository.deleteByIdentifier(identifier);
         response.setHeader("Set-Cookie", cookieComponent.deleteRefreshToken());

--- a/src/main/java/kakao/festapick/user/service/UserService.java
+++ b/src/main/java/kakao/festapick/user/service/UserService.java
@@ -44,9 +44,7 @@ public class UserService {
 
         UserEntity findUser = userLowService.findByIdentifier(identifier);
 
-        wishRepository.deleteByUserId(findUser.getId());
-        reviewService.deleteReviewByUserId(findUser.getId());
-        festivalService.deleteFestivalByManagerId(findUser.getId());
+        deleteRelatedEntity(findUser);
 
         userLowService.deleteByIdentifier(identifier);
         response.setHeader("Set-Cookie", cookieComponent.deleteRefreshToken());
@@ -85,9 +83,17 @@ public class UserService {
     public void deleteUser(Long id) {
         UserEntity findUser = userLowService.findById(id);
 
+        deleteRelatedEntity(findUser);
+
         userLowService.deleteById(findUser.getId());
 
         s3Service.deleteS3File(findUser.getProfileImageUrl()); // s3 파일 삭제는 항상 마지막에 호출
+    }
+
+    private void deleteRelatedEntity(UserEntity findUser) {
+        wishRepository.deleteByUserId(findUser.getId());
+        reviewService.deleteReviewByUserId(findUser.getId());
+        festivalService.deleteFestivalByManagerId(findUser.getId());
     }
 
 

--- a/src/main/java/kakao/festapick/wish/repository/WishRepository.java
+++ b/src/main/java/kakao/festapick/wish/repository/WishRepository.java
@@ -5,6 +5,7 @@ import kakao.festapick.wish.domain.Wish;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +19,8 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
     Optional<Wish> findByUserIdentifierAndFestivalId(String identifier, Long festivalId);
 
     Optional<Wish> findByUserIdentifierAndId(String identifier, Long wishId);
+
+    @Modifying
+    @Query("delete from Wish w where w.user.id = :userId")
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/kakao/festapick/wish/repository/WishRepository.java
+++ b/src/main/java/kakao/festapick/wish/repository/WishRepository.java
@@ -21,11 +21,11 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
 
     Optional<Wish> findByUserIdentifierAndId(String identifier, Long wishId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from Wish w where w.user.id = :userId")
     void deleteByUserId(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from Wish w where w.festival.id = :festivalId")
     void deleteByFestivalId(Long festivalId);
 

--- a/src/main/java/kakao/festapick/wish/repository/WishRepository.java
+++ b/src/main/java/kakao/festapick/wish/repository/WishRepository.java
@@ -1,5 +1,6 @@
 package kakao.festapick.wish.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kakao.festapick.wish.domain.Wish;
 import org.springframework.data.domain.Page;
@@ -23,4 +24,11 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
     @Modifying
     @Query("delete from Wish w where w.user.id = :userId")
     void deleteByUserId(Long userId);
+
+    @Modifying
+    @Query("delete from Wish w where w.festival.id = :festivalId")
+    void deleteByFestivalId(Long festivalId);
+
+    @Query("select w from Wish w where w.festival.id = :festivalId")
+    List<Wish> findByFestivalId(Long festivalId);
 }

--- a/src/main/java/kakao/festapick/wish/service/WishService.java
+++ b/src/main/java/kakao/festapick/wish/service/WishService.java
@@ -8,6 +8,7 @@ import kakao.festapick.global.exception.DuplicateEntityException;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
 import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import kakao.festapick.wish.domain.Wish;
 import kakao.festapick.wish.dto.WishResponseDto;
@@ -24,14 +25,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class WishService {
 
     private final WishRepository wishRepository;
-    private final UserService userService;
+    private final UserLowService userLowService;
     private final FestivalRepository festivalRepository;
 
     @Transactional
     public WishResponseDto createWish(Long festivalId, String identifier) {
         Festival festival = festivalRepository.findFestivalById(festivalId)
                 .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.FESTIVAL_NOT_FOUND));
-        UserEntity user = userService.findByIdentifier(identifier);
+        UserEntity user = userLowService.findByIdentifier(identifier);
 
         wishRepository.findByUserIdentifierAndFestivalId(identifier, festivalId)
                 .ifPresent(w -> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,7 +53,7 @@ spring.cookie.same=Lax
 spring.cookie.secure=false
 
 #origin
-spring.front.domain=http://localhost:3000
+spring.front.domain=http://localhost:5174
 spring.backend.domain=http://localhost:8080
 
 #HMAC-SHA256

--- a/src/test/java/kakao/festapick/festival/controller/FestivalUserControllerTest.java
+++ b/src/test/java/kakao/festapick/festival/controller/FestivalUserControllerTest.java
@@ -63,7 +63,6 @@ class FestivalUserControllerTest {
 
     @Autowired private TestUtil testUtil;
 
-    @Autowired private EntityManager em;
 
     @BeforeEach
     void initTestDB() throws Exception {
@@ -286,9 +285,6 @@ class FestivalUserControllerTest {
             wishRepository.save(new Wish(testUser, saved));
         }
 
-        flushAndClear();
-
-
         //when-then
         mockMvc.perform(delete("/api/festivals/{festivalId}", saved.getId()))
                 .andExpect(status().is(HttpStatus.NO_CONTENT.value()));
@@ -347,10 +343,6 @@ class FestivalUserControllerTest {
                 LocalDate.now(), LocalDate.now(), "homePage", overview);
     }
 
-    private void flushAndClear() {
-        em.flush();
-        em.clear();
-    }
 
 
 }

--- a/src/test/java/kakao/festapick/jwt/service/JwtServiceTest.java
+++ b/src/test/java/kakao/festapick/jwt/service/JwtServiceTest.java
@@ -22,6 +22,7 @@ import kakao.festapick.jwt.domain.RefreshToken;
 import kakao.festapick.jwt.repository.RefreshTokenRepository;
 import kakao.festapick.jwt.util.JwtUtil;
 import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import kakao.festapick.util.TestUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -44,7 +45,7 @@ class JwtServiceTest {
     private RefreshTokenRepository refreshTokenRepository;
 
     @Mock
-    private UserService userService;
+    private UserLowService userLowService;
 
     @Mock
     private JwtUtil jwtUtil;
@@ -65,7 +66,7 @@ class JwtServiceTest {
         String refreshToken = UUID.randomUUID().toString();
         UserEntity userEntity = testUtil.createTestUser();
 
-        given(userService.findByIdentifier(any()))
+        given(userLowService.findByIdentifier(any()))
                 .willReturn(userEntity);
 
         given(tokenEncoder.encode(any()))
@@ -86,7 +87,7 @@ class JwtServiceTest {
                 }
         );
 
-        verify(userService).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(refreshTokenRepository).deleteByUser(any());
         verify(tokenEncoder).encode(any());
         verify(refreshTokenRepository).save(any());
@@ -127,7 +128,7 @@ class JwtServiceTest {
                 .willReturn(true);
 
 
-        given(userService.findByIdentifier(any()))
+        given(userLowService.findByIdentifier(any()))
                 .willReturn(userEntity);
 
         given(refreshTokenRepository.save(any()))
@@ -147,13 +148,13 @@ class JwtServiceTest {
                     softly.assertThat(response.getHeader("Set-Cookie")).isEqualTo(setCookieHeader);
                 }
         );
-        verify(userService).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(refreshTokenRepository).deleteByUser(any());
         verify(refreshTokenRepository).save(any());
         verify(jwtUtil).getClaims(any());
         verify(jwtUtil).validateToken(any(), any());
         verify(jwtUtil, times(2)).createJWT(any(), any(), any());
-        verifyNoMoreInteractions(userService, jwtUtil, refreshTokenRepository, cookieComponent);
+        verifyNoMoreInteractions(userLowService, jwtUtil, refreshTokenRepository, cookieComponent);
     }
 
     @Test
@@ -169,7 +170,7 @@ class JwtServiceTest {
         assertThatThrownBy(()->jwtService.exchangeToken(request,response))
                 .isInstanceOf(AuthenticationException.class)
                 .hasMessage(ExceptionCode.COOKIE_NOT_EXIST.getErrorMessage());
-        verifyNoMoreInteractions(userService, jwtUtil, refreshTokenRepository, cookieComponent);
+        verifyNoMoreInteractions(userLowService, jwtUtil, refreshTokenRepository, cookieComponent);
 
     }
 
@@ -187,7 +188,7 @@ class JwtServiceTest {
         assertThatThrownBy(()->jwtService.exchangeToken(request,response))
                 .isInstanceOf(AuthenticationException.class)
                 .hasMessage(ExceptionCode.REFRESH_TOKEN_NOT_EXIST.getErrorMessage());
-        verifyNoMoreInteractions(userService, jwtUtil, refreshTokenRepository, cookieComponent);
+        verifyNoMoreInteractions(userLowService, jwtUtil, refreshTokenRepository, cookieComponent);
     }
 
     @Test
@@ -208,7 +209,7 @@ class JwtServiceTest {
                 .isInstanceOf(AuthenticationException.class)
                 .hasMessage(ExceptionCode.INVALID_REFRESH_TOKEN.getErrorMessage());
         verify(jwtUtil).validateToken(any(), any());
-        verifyNoMoreInteractions(userService, jwtUtil, refreshTokenRepository, cookieComponent);
+        verifyNoMoreInteractions(userLowService, jwtUtil, refreshTokenRepository, cookieComponent);
     }
 
 }

--- a/src/test/java/kakao/festapick/review/service/ReviewServiceTest.java
+++ b/src/test/java/kakao/festapick/review/service/ReviewServiceTest.java
@@ -27,6 +27,7 @@ import kakao.festapick.review.dto.ReviewRequestDto;
 import kakao.festapick.review.dto.ReviewResponseDto;
 import kakao.festapick.review.repository.ReviewRepository;
 import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import kakao.festapick.util.TestUtil;
 import org.junit.jupiter.api.Assertions;
@@ -44,7 +45,7 @@ public class ReviewServiceTest {
     private ReviewService reviewService;
 
     @Mock
-    private UserService userService;
+    private UserLowService userLowService;
 
     @Mock
     private FestivalRepository festivalRepository;
@@ -74,7 +75,7 @@ public class ReviewServiceTest {
 
         given(festivalRepository.findFestivalById(any()))
                 .willReturn(Optional.of(festival));
-        given(userService.findByIdentifier(any()))
+        given(userLowService.findByIdentifier(any()))
                 .willReturn(user);
         given(reviewRepository.existsByUserIdAndFestivalId(any(), any()))
                 .willReturn(false);
@@ -89,12 +90,12 @@ public class ReviewServiceTest {
         assertThat(review.getId()).isEqualTo(savedId);
 
         verify(festivalRepository).findFestivalById(any());
-        verify(userService).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(reviewRepository).existsByUserIdAndFestivalId(any(), any());
         verify(reviewRepository).save(any());
         verify(fileService).saveAll(anyList());
         verify(temporalFileRepository).deleteByIds(any());
-        verifyNoMoreInteractions(festivalRepository,userService,reviewRepository,fileService, temporalFileRepository);
+        verifyNoMoreInteractions(festivalRepository,userLowService,reviewRepository,fileService, temporalFileRepository);
     }
 
     @Test
@@ -107,7 +108,7 @@ public class ReviewServiceTest {
 
         given(festivalRepository.findFestivalById(any()))
                 .willReturn(Optional.of(festival));
-        given(userService.findByIdentifier(any()))
+        given(userLowService.findByIdentifier(any()))
                 .willReturn(user);
         given(reviewRepository.existsByUserIdAndFestivalId(any(), any()))
                 .willReturn(true);
@@ -119,9 +120,9 @@ public class ReviewServiceTest {
         assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.REVIEW_DUPLICATE);
 
         verify(festivalRepository).findFestivalById(any());
-        verify(userService).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(reviewRepository).existsByUserIdAndFestivalId(any(), any());
-        verifyNoMoreInteractions(festivalRepository,userService,reviewRepository,fileService, temporalFileRepository);
+        verifyNoMoreInteractions(festivalRepository,userLowService,reviewRepository,fileService, temporalFileRepository);
     }
 
     @Test
@@ -140,7 +141,7 @@ public class ReviewServiceTest {
 
         verify(reviewRepository).deleteByUserIdentifierAndId(any(), any());
         verify(fileService).deleteByDomainId(any(),any());
-        verifyNoMoreInteractions(festivalRepository,userService,reviewRepository,fileService);
+        verifyNoMoreInteractions(festivalRepository,userLowService,reviewRepository,fileService);
     }
 
 
@@ -162,7 +163,7 @@ public class ReviewServiceTest {
         assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.REVIEW_NOT_FOUND);
 
         verify(reviewRepository).deleteByUserIdentifierAndId(any(), any());
-        verifyNoMoreInteractions(festivalRepository,userService,reviewRepository,fileService);
+        verifyNoMoreInteractions(festivalRepository,userLowService,reviewRepository,fileService);
     }
 
     @Test
@@ -189,7 +190,7 @@ public class ReviewServiceTest {
         verify(fileService).deleteAllByFileEntity(any());
         verify(temporalFileRepository).deleteByIds(any());
         verify(s3Service).deleteFiles(any());
-        verifyNoMoreInteractions(festivalRepository,userService,reviewRepository,fileService, temporalFileRepository);
+        verifyNoMoreInteractions(festivalRepository,userLowService,reviewRepository,fileService, temporalFileRepository);
     }
 
     @Test
@@ -211,7 +212,7 @@ public class ReviewServiceTest {
         assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.REVIEW_NOT_FOUND);
 
         verify(reviewRepository).findByUserIdentifierAndId(any(), any());
-        verifyNoMoreInteractions(festivalRepository,userService,reviewRepository,fileService, temporalFileRepository);
+        verifyNoMoreInteractions(festivalRepository,userLowService,reviewRepository,fileService, temporalFileRepository);
     }
 
     @Test

--- a/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
+++ b/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
@@ -54,10 +54,6 @@ class UserControllerTest {
     private FestivalRepository festivalRepository;
 
     @Autowired
-    private EntityManager em;
-
-
-    @Autowired
     private ObjectMapper objectMapper;
 
     private static final String identifier = "GOOGLE_1234";
@@ -75,8 +71,6 @@ class UserControllerTest {
         for (int i=0; i<3; i++) {
             festivalRepository.save(testUtil.createTestFestival(userEntity));
         }
-
-        flushAndClear();
 
         // when & then
         mockMvc.perform(delete("/api/users"))
@@ -147,13 +141,5 @@ class UserControllerTest {
 
         return userRepository.save(testUtil.createTestUser(identifier));
     }
-
-    private void flushAndClear() {
-        em.flush();
-        em.clear();
-    }
-
-
-
 
 }

--- a/src/test/java/kakao/festapick/user/service/UserServiceTest.java
+++ b/src/test/java/kakao/festapick/user/service/UserServiceTest.java
@@ -30,7 +30,7 @@ public class UserServiceTest {
     private UserService userService;
 
     @Mock
-    private UserRepository userRepository;
+    private UserLowService userLowService;
 
     @Mock
     private CookieComponent cookieComponent;
@@ -49,17 +49,17 @@ public class UserServiceTest {
         UserEntity userEntity = new UserEntity("GOOGLE-1234",
                 "example@gmail.com", "exampleName", UserRoleType.USER, SocialType.GOOGLE);
 
-        given(userRepository.findByIdentifier(any()))
-                .willReturn(Optional.of(userEntity));
+        given(userLowService.findByIdentifier(any()))
+                .willReturn(userEntity);
 
         // when
         userService.changeProfileImage(userEntity.getIdentifier(), new FileUploadRequest(1L,"updateImageUrl"));
 
         // then
-        verify(userRepository).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(s3Service).deleteS3File(any());
         verify(temporalFileRepository).deleteById(any());
-        verifyNoMoreInteractions(userRepository,s3Service, temporalFileRepository,cookieComponent);
+        verifyNoMoreInteractions(userLowService,s3Service, temporalFileRepository,cookieComponent);
 
     }
 
@@ -69,15 +69,15 @@ public class UserServiceTest {
 
         // given
 
-        given(userRepository.findByIdentifier(any()))
-                .willReturn(Optional.empty());
+        given(userLowService.findByIdentifier(any()))
+                .willThrow(NotFoundEntityException.class);
 
         // when & then
         assertThatThrownBy(()->
                 userService.changeProfileImage("GOOGLE-1234", new FileUploadRequest(1L,"updateImageUrl"))
         ).isInstanceOf(NotFoundEntityException.class);
-        verify(userRepository).findByIdentifier(any());
-        verifyNoMoreInteractions(userRepository,s3Service, temporalFileRepository,cookieComponent);
+        verify(userLowService).findByIdentifier(any());
+        verifyNoMoreInteractions(userLowService,s3Service, temporalFileRepository,cookieComponent);
 
     }
 }

--- a/src/test/java/kakao/festapick/util/TestUtil.java
+++ b/src/test/java/kakao/festapick/util/TestUtil.java
@@ -5,6 +5,9 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+
+import kakao.festapick.festival.domain.Festival;
+import kakao.festapick.festival.domain.FestivalState;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 import kakao.festapick.user.domain.SocialType;
@@ -25,6 +28,10 @@ public class TestUtil {
 
     public UserEntity createTestManager(String identifier){
         return new UserEntity(identifier, "example@gmail.com", "exampleName", UserRoleType.FESTIVAL_MANAGER, SocialType.GOOGLE);
+    }
+
+    public Festival createTestFestival(UserEntity userEntity) {
+        return new Festival("부산대축제", 1,"주소1", null, "postImageUrl",toLocalDate("20250810"), toLocalDate("20250820"),"overView", "hompage", FestivalState.APPROVED, userEntity, null);
     }
 
     public LocalDate toLocalDate(String date){

--- a/src/test/java/kakao/festapick/wish/service/WishServiceTest.java
+++ b/src/test/java/kakao/festapick/wish/service/WishServiceTest.java
@@ -17,6 +17,7 @@ import kakao.festapick.global.exception.DuplicateEntityException;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
 import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
 import kakao.festapick.user.service.UserService;
 import kakao.festapick.util.TestUtil;
 import kakao.festapick.wish.domain.Wish;
@@ -38,7 +39,7 @@ public class WishServiceTest {
     private WishService wishService;
 
     @Mock
-    private UserService userService;
+    private UserLowService userLowService;
 
     @Mock
     private FestivalRepository festivalRepository;
@@ -57,7 +58,7 @@ public class WishServiceTest {
 
         given(festivalRepository.findFestivalById(any()))
                 .willReturn(Optional.of(festival));
-        given(userService.findByIdentifier(any()))
+        given(userLowService.findByIdentifier(any()))
                 .willReturn(user);
         given(wishRepository.findByUserIdentifierAndFestivalId(any(), any()))
                 .willReturn(Optional.empty());
@@ -78,11 +79,11 @@ public class WishServiceTest {
         );
 
         verify(festivalRepository).findFestivalById(any());
-        verify(userService).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(wishRepository).findByUserIdentifierAndFestivalId(any(), any());
         verify(wishRepository).save(any());
         verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(userService);
+        verifyNoMoreInteractions(userLowService);
         verifyNoMoreInteractions(wishRepository);
     }
 
@@ -95,7 +96,7 @@ public class WishServiceTest {
 
         given(festivalRepository.findFestivalById(any()))
                 .willReturn(Optional.of(festival));
-        given(userService.findByIdentifier(any()))
+        given(userLowService.findByIdentifier(any()))
                 .willReturn(user);
         given(wishRepository.findByUserIdentifierAndFestivalId(any(), any()))
                 .willReturn(Optional.of(wish));
@@ -105,10 +106,10 @@ public class WishServiceTest {
         assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.WISH_DUPLICATE);
 
         verify(festivalRepository).findFestivalById(any());
-        verify(userService).findByIdentifier(any());
+        verify(userLowService).findByIdentifier(any());
         verify(wishRepository).findByUserIdentifierAndFestivalId(any(), any());
         verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(userService);
+        verifyNoMoreInteractions(userLowService);
         verifyNoMoreInteractions(wishRepository);
     }
 
@@ -127,7 +128,7 @@ public class WishServiceTest {
         verify(wishRepository).findByUserIdentifierAndId(any(), any());
         verify(wishRepository).delete(any());
         verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(userService);
+        verifyNoMoreInteractions(userLowService);
         verifyNoMoreInteractions(wishRepository);
     }
 
@@ -147,7 +148,7 @@ public class WishServiceTest {
 
         verify(wishRepository).findByUserIdentifierAndId(any(), any());
         verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(userService);
+        verifyNoMoreInteractions(userLowService);
         verifyNoMoreInteractions(wishRepository);
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -55,7 +55,7 @@ spring.cookie.same=Lax
 spring.cookie.secure=false
 
 #origin
-spring.front.domain=http://localhost:3000
+spring.front.domain=http://localhost:5174
 spring.backend.domain=http://localhost:8080
 
 #HMAC-SHA256


### PR DESCRIPTION
close #24 

## 기존 코드 문제점

기존 코드는 모두 `CascadeType.ALL`을 통해서 특정 엔티티를 삭제시 해당 엔티티와 연관관계를 맺은 모든 엔티티를 삭제했었습니다.

기존 `CascadeType.ALL` 방식의 문제점은 다음과 같습니다.

### 1. N+1 문제

<img width="356" height="245" alt="스크린샷 2025-09-15 오후 8 36 58" src="https://github.com/user-attachments/assets/d8efc721-e027-4982-911b-31c20bb84526" />

위 코드는 10개의 `Wish`(좋아요)를 받은 `Festival`을 삭제하는 코드를 실행시킨 결과입니다.

기존 코드는 `Festival`을 삭제하면, 연관되어있는 `Wish`의 수만큼 `delete` 쿼리를 날립니다.

### 2. FileEntity 미삭제 문제

기존에는 `UserEntity`가 삭제되면 `CascadeType`으로 `Wish`, `Review`, `Festival`, `RefreshToken`이 모두 삭제되었습니다.

하지만, 이는 치명적인 문제를 내포합니다.

`FileEntity`는 `Festival`, `Review`와 연관관계를 맺고 있지 않기 때문에 `CascadeType`으로 인한 삭제 대상이 아닙니다.

## 결론 : 변경 사항

### 1. 벌크 연산 활용

`RefreshToken`을 제외한 모든 양방향 연관관계를 단방향 연관관계로 바꿈으로써 `CascadeType` 대신 `벌크 연산`을 사용하는 코드로 바꿨습니다.

<img width="727" height="199" alt="스크린샷 2025-09-15 오후 9 53 10" src="https://github.com/user-attachments/assets/90e2e6f3-d3ee-4f3d-adc6-ff360175d645" />

만약 `Festival`을 삭제하면, `delete` 쿼리는 고정적으로 5개가 실행됩니다.

1. `Wish` 삭제 쿼리
2. `Review` 파일 삭제 쿼리
3. `Review` 삭제 쿼리
4. `Festival` 파일 삭제 쿼리
5. `Festival` 삭제 쿼리

### 2. UserLowService

서비스간 연쇄참조 현상이 발생해서 `UserEntity`에 대한 간단한 쿼리를 날리는 메서드는 모두 `UserLowService`로 이관했습니다.