### PR TITLE
TourAPI에서 예외가 XML로 던져지는 것에 대한 예외 처리 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	// aws
 	implementation libs.aws.s3
+
+	// XmlMapper
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 }
 
 tasks.named('test') {

--- a/src/main/java/kakao/festapick/festival/TourInfoScheduler.java
+++ b/src/main/java/kakao/festapick/festival/TourInfoScheduler.java
@@ -1,5 +1,8 @@
 package kakao.festapick.festival;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -14,11 +17,13 @@ import kakao.festapick.festival.tourapi.TourApiMaxRows;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
 import kakao.festapick.festival.tourapi.TourImagesResponse;
 import kakao.festapick.festival.tourapi.TourInfoResponse;
+import kakao.festapick.festival.tourapi.response.TourApiExceptionMessage;
 import kakao.festapick.festival.tourapi.response.TourApiResponse.FestivalInfo;
 import kakao.festapick.fileupload.domain.DomainType;
 import kakao.festapick.fileupload.domain.FileEntity;
 import kakao.festapick.fileupload.domain.FileType;
 import kakao.festapick.fileupload.repository.FileJdbcTemplateRepository;
+import kakao.festapick.global.exception.TourApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,18 +53,23 @@ public class TourInfoScheduler {
 
     private final RestClient tourApiClient;
 
+    private final ObjectMapper objectMapper;
+
     @GetMapping("/update") //// 테스트용 - 개발 완료시 삭제할 것
     @Transactional
-    @Scheduled(cron = "0 15 17 * * *")
-    public void fetchFestivals() {
+    @Scheduled(cron = "0 10 3 * * *")
+    public void fetchFestivals() throws JsonProcessingException {
         int maxRows = getMaxColumns();
         if (maxRows > 0) {
             log.info("가져올 축제 정보 수 : {}", maxRows);
-            TourInfoResponse tourApiResponse = getFestivals(maxRows).getBody();
+            TourInfoResponse tourApiResponse = getFestivals(maxRows);
             List<FestivalRequestDto> festivalList = tourApiResponse.getFestivalResponseDtoList();
-            List<Festival> festivals = festivalList.parallelStream()
-                    .map(requestDto -> new Festival(requestDto, getDetails(requestDto.contentId())))
-                    .toList();
+
+            List<Festival> festivals = new ArrayList<>();
+            for (FestivalRequestDto requestDto : festivalList) {
+                festivals.add(new Festival(requestDto, getDetails(requestDto.contentId())));
+            }
+
             festivalJdbcTemplateRepository.upsertFestivalInfo(festivals);
             log.info("축제 정보 저장 완료");
 
@@ -73,16 +83,19 @@ public class TourInfoScheduler {
         }
     }
 
-    private void saveImages(Map<String, Long> idMap) {
+    private void saveImages(Map<String, Long> idMap) throws JsonProcessingException {
         //새로운 이미지 저장하기
         List<FileEntity> files = new ArrayList<>();
         Map<String, String> posters = new HashMap<>();
 
         //이미지 저장 및 대표 이미지를 포스터로 변경
-        List<TourImagesResponse> tourImagesResponseList = idMap.keySet()
-                .parallelStream().map(contentId -> getDetailImages(contentId))
-                .filter(imagesResponse -> imagesResponse.getNumOfRows() > 0)
-                .toList();
+        List<TourImagesResponse> tourImagesResponseList = new ArrayList<>();
+        for (String contentId : idMap.keySet()) {
+            TourImagesResponse imagesResponse = getDetailImages(contentId);
+            if(imagesResponse.getNumOfRows() > 0){
+                tourImagesResponseList.add(imagesResponse);
+            }
+        }
 
         for (TourImagesResponse tourImagesResponse : tourImagesResponseList) {
             for (FestivalInfo imageInfo : tourImagesResponse.getImageInfos()) {
@@ -101,8 +114,8 @@ public class TourInfoScheduler {
     }
 
 
-    private ResponseEntity<TourInfoResponse> getFestivals(int numOfRows) {
-        ResponseEntity<TourInfoResponse> response = tourApiClient.get()
+    private TourInfoResponse getFestivals(int numOfRows) throws JsonProcessingException {
+        ResponseEntity<String> response = tourApiClient.get()
                 .uri(uriBuilder -> uriBuilder.path("/B551011/KorService2/searchFestival2")
                         .queryParam("MobileOS", "ETC")
                         .queryParam("MobileApp", "FestaPick")
@@ -111,14 +124,23 @@ public class TourInfoScheduler {
                         .queryParam("_type", "json")
                         .queryParam("numOfRows", numOfRows)
                         .build())
-                .accept(MediaType.APPLICATION_JSON)
+                .accept(MediaType.ALL)
                 .retrieve()
-                .toEntity(TourInfoResponse.class);
-        return response;
+                .toEntity(String.class);
+
+        String body = response.getBody();
+        MediaType mediaType = response.getHeaders().getContentType();
+
+        // 정상적인 응답이 들어온 경우
+        if(mediaType != null && mediaType.includes(MediaType.APPLICATION_JSON)){
+            return objectMapper.readValue(body, TourInfoResponse.class);
+        }
+
+        throw new TourApiException(getErrorMessage(body));
     }
 
-    private TourDetailResponse getDetails(String contentId) {
-        ResponseEntity<TourDetailResponse> response = tourApiClient.get()
+    private TourDetailResponse getDetails(String contentId) throws JsonProcessingException {
+        ResponseEntity<String> response = tourApiClient.get()
                 .uri(uriBuilder -> uriBuilder.path("/B551011/KorService2/detailCommon2")
                         .queryParam("MobileOS", "ETC")
                         .queryParam("MobileApp", "FestaPick")
@@ -126,14 +148,22 @@ public class TourInfoScheduler {
                         .queryParam("serviceKey", tourApiKey)
                         .queryParam("_type", "json")
                         .build())
-                .accept(MediaType.APPLICATION_JSON)
+                .accept(MediaType.ALL)
                 .retrieve()
-                .toEntity(TourDetailResponse.class);
-        return response.getBody();
+                .toEntity(String.class);
+
+        String body = response.getBody();
+        MediaType mediaType = response.getHeaders().getContentType();
+
+        if(mediaType != null && mediaType.includes(MediaType.APPLICATION_JSON)){
+            return objectMapper.readValue(body, TourDetailResponse.class);
+        }
+
+        throw new TourApiException(getErrorMessage(body));
     }
 
-    private TourImagesResponse getDetailImages(String contentId) {
-        ResponseEntity<TourImagesResponse> response = tourApiClient.get()
+    private TourImagesResponse getDetailImages(String contentId) throws JsonProcessingException {
+        ResponseEntity<String> response = tourApiClient.get()
                 .uri(uriBuilder -> uriBuilder.path("/B551011/KorService2/detailImage2")
                         .queryParam("MobileOS", "ETC")
                         .queryParam("MobileApp", "FestaPick")
@@ -141,14 +171,22 @@ public class TourInfoScheduler {
                         .queryParam("serviceKey", tourApiKey)
                         .queryParam("_type", "json")
                         .build())
-                .accept(MediaType.APPLICATION_JSON)
+                .accept(MediaType.ALL)
                 .retrieve()
-                .toEntity(TourImagesResponse.class);
-        return response.getBody();
+                .toEntity(String.class);
+
+        String body = response.getBody();
+        MediaType mediaType = response.getHeaders().getContentType();
+
+        if(mediaType != null && mediaType.includes(MediaType.APPLICATION_JSON)){
+            return objectMapper.readValue(body, TourImagesResponse.class);
+        }
+
+        throw new TourApiException(getErrorMessage(body));
     }
 
-    private int getMaxColumns() {
-        ResponseEntity<TourApiMaxRows> response = tourApiClient.get()
+    private int getMaxColumns() throws JsonProcessingException {
+        ResponseEntity<String> response = tourApiClient.get()
                 .uri(uriBuilder -> uriBuilder.path("/B551011/KorService2/searchFestival2")
                         .queryParam("MobileOS", "ETC")
                         .queryParam("MobileApp", "FestaPick")
@@ -157,10 +195,26 @@ public class TourInfoScheduler {
                         .queryParam("_type", "json")
                         .queryParam("numOfRows", 1)
                         .build())
-                .accept(MediaType.APPLICATION_JSON)
+                .accept(MediaType.ALL)
                 .retrieve()
-                .toEntity(TourApiMaxRows.class);
-        return (response.getBody() != null) ? response.getBody().getMaxColumns() : 0;
+                .toEntity(String.class);
+
+        String body = response.getBody();
+        MediaType mediaType = response.getHeaders().getContentType();
+
+        if(mediaType != null && mediaType.includes(MediaType.APPLICATION_JSON)){
+            TourApiMaxRows tourApiMaxRows = objectMapper.readValue(body, TourApiMaxRows.class);
+            return tourApiMaxRows.getMaxColumns();
+        }
+
+        throw new TourApiException(getErrorMessage(body));
+    }
+
+    // TourAPI로 부터 오류 응답(XML)이 들어오는 경우
+    private String getErrorMessage(String xml) throws JsonProcessingException {
+        XmlMapper xmlMapper = new XmlMapper();
+        TourApiExceptionMessage tourApiExceptionMessage = xmlMapper.readValue(xml, TourApiExceptionMessage.class);
+        return tourApiExceptionMessage.getCmmMsgHeader().getReturnAuthMsg();
     }
 
     private String getDate() {

--- a/src/main/java/kakao/festapick/festival/tourapi/response/TourApiExceptionMessage.java
+++ b/src/main/java/kakao/festapick/festival/tourapi/response/TourApiExceptionMessage.java
@@ -1,0 +1,21 @@
+package kakao.festapick.festival.tourapi.response;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.Getter;
+
+@Getter
+@JacksonXmlRootElement(localName = "OpenAPI_ServiceResponse")
+public class TourApiExceptionMessage {
+
+    private CmmMsgHeader cmmMsgHeader;
+
+    @Getter
+    public static class CmmMsgHeader {
+
+        private String errMsg;
+
+        private String returnAuthMsg;
+
+        private int returnReasonCode;
+    }
+}

--- a/src/main/java/kakao/festapick/global/GlobalExceptionHandler.java
+++ b/src/main/java/kakao/festapick/global/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import kakao.festapick.global.exception.AuthenticationException;
 import kakao.festapick.global.exception.BadRequestException;
 import kakao.festapick.global.exception.DuplicateEntityException;
 import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.global.exception.TourApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,10 +45,9 @@ public class GlobalExceptionHandler {
         log.error("timeout 발생 : " + e.getMessage());
     }
 
-    @ExceptionHandler(UnknownContentTypeException.class)
-    public void handelRestClientLimitException(UnknownContentTypeException e){
-        log.error("1일 API 호출 횟수 초과");
-        log.error("인증키 만료");
+    @ExceptionHandler(TourApiException.class)
+    public void handelRestClientLimitException(TourApiException e){
+        log.error(e.getErrMsg());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/kakao/festapick/global/exception/TourApiException.java
+++ b/src/main/java/kakao/festapick/global/exception/TourApiException.java
@@ -1,0 +1,14 @@
+package kakao.festapick.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TourApiException extends RuntimeException{
+
+    private String errMsg;
+
+    public TourApiException(String errMsg) {
+        super(errMsg);
+        this.errMsg = errMsg;
+    }
+}

--- a/src/main/java/kakao/festapick/user/repository/UserRepository.java
+++ b/src/main/java/kakao/festapick/user/repository/UserRepository.java
@@ -9,7 +9,5 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByIdentifier(String identifier);
 
-    void deleteByIdentifier(String identifier);
-
     String id(Long id);
 }

--- a/src/main/java/kakao/festapick/user/service/UserLowService.java
+++ b/src/main/java/kakao/festapick/user/service/UserLowService.java
@@ -20,10 +20,6 @@ public class UserLowService {
                 .orElseThrow(()->new NotFoundEntityException(ExceptionCode.USER_NOT_FOUND));
     }
 
-    public void deleteByIdentifier(String identifier) {
-        userRepository.deleteByIdentifier(identifier);
-    }
-
     public UserEntity findById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(()->new NotFoundEntityException(ExceptionCode.USER_NOT_FOUND));


### PR DESCRIPTION
close: #37 

- TourAPI(공공데이터포털 API)에서는 예외를 항상 XML로 반환합니다. (지정한 반환 타입과 무관하게 항상 XML로 반환)
   ```xml
    <OpenAPI_ServiceResponse>
	    <cmmMsgHeader>
		    <errMsg>SERVICE ERROR</errMsg>
		    <returnAuthMsg>SERVICE_KEY_IS_NOT_REGISTERED_ERROR</returnAuthMsg>
		    <returnReasonCode>30</returnReasonCode>
	    </cmmMsgHeader>
    </OpenAPI_ServiceResponse>
   ```

- 이전에는 XML 응답이 반환되는 경우 자체를 예외 처리했지만, 추후 운영에 있어 상세한 에러 메시지가 있으면 좋겠다고 생각해 개선 작업을 수행했습니다. 

- XmlMapper를 통해 XML로 들어온 응답에 대해 파싱을 수행했습니다.

- 잘못된 API 키를 통해 호출하는 경우 예외가 발생하고, 응답받은 메시지를 로그로 남겼습니다.

  <img width="975" height="32" alt="image" src="https://github.com/user-attachments/assets/d4c9dc16-5ba4-47cd-af95-3454ec19c4b7" />





