### PR TITLE
docs: Swagger를 통한 API 명세서 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ dependencies {
 	// XmlMapper
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 tasks.named('test') {

--- a/src/main/java/kakao/festapick/config/SecurityConfig.java
+++ b/src/main/java/kakao/festapick/config/SecurityConfig.java
@@ -109,6 +109,8 @@ public class SecurityConfig {
             "/view/**", //view 확인용
             "/management/health_check",
             "/stomp/**",
-            "/api/login/status"
+            "/api/login/status",
+            "/swagger-ui/**", // swagger
+            "/v3/api-docs/**"
     };
 }

--- a/src/main/java/kakao/festapick/config/SwaggerConfig.java
+++ b/src/main/java/kakao/festapick/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package kakao.festapick.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI(){
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FestaPick API")
+                        .version("v2.0.1"))
+                .servers(List.of(
+                        new Server()
+                                .url("https://localhost:8080")
+                                .description("개발용 서버")
+                ))
+                .components(new Components().addSecuritySchemes("JWT", new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .in(SecurityScheme.In.HEADER)
+                        .name("Authorization")
+                    )
+                );
+    }
+
+}

--- a/src/main/java/kakao/festapick/config/SwaggerConfig.java
+++ b/src/main/java/kakao/festapick/config/SwaggerConfig.java
@@ -6,11 +6,15 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
+    @Value("${spring.backend.domain}")
+    private String serverDomain;
 
     @Bean
     public OpenAPI openAPI(){
@@ -20,7 +24,7 @@ public class SwaggerConfig {
                         .version("v2.0.1"))
                 .servers(List.of(
                         new Server()
-                                .url("https://localhost:8080")
+                                .url(serverDomain)
                                 .description("개발용 서버")
                 ))
                 .components(new Components().addSecuritySchemes("JWT", new SecurityScheme()

--- a/src/main/java/kakao/festapick/festival/controller/FestivalUserController.java
+++ b/src/main/java/kakao/festapick/festival/controller/FestivalUserController.java
@@ -1,5 +1,8 @@
 package kakao.festapick.festival.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import kakao.festapick.dto.ApiResponseDto;
@@ -24,11 +27,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/festivals")
 @RequiredArgsConstructor
+@Tag(name = "Festival API", description = "축제 도메인 API")
 public class FestivalUserController {
 
     private final FestivalService festivalService;
 
-    //축제 등록
+    @Operation(
+            summary = "축제 등록 기능",
+            security = @SecurityRequirement(name = "JWT"))
     @PostMapping
     @PreAuthorize("hasRole('ROLE_FESTIVAL_MANAGER')")
     public ResponseEntity<Void> addFestival(
@@ -39,7 +45,7 @@ public class FestivalUserController {
         return ResponseEntity.created(URI.create("/api/festivals/" + festivalId)).build();
     }
 
-    //해당 지역에서 현재 참여할 수 있는 축제
+    @Operation(summary = "해당 지역에서 현재 참여할 수 있는 축제 조회")
     @GetMapping("/area/{areaCode}")
     public ResponseEntity<Page<FestivalListResponse>> getCurrentFestivalByArea(
             @PathVariable int areaCode,
@@ -50,7 +56,7 @@ public class FestivalUserController {
         return ResponseEntity.ok(festivalResponseDtos);
     }
 
-    //축제 상세 조회
+    @Operation(summary = "축제 상세 조회")
     @GetMapping("/{festivalId}")
     public ResponseEntity<ApiResponseDto<FestivalDetailResponseDto>> getFestivalInfo(@PathVariable Long festivalId){
         FestivalDetailResponseDto festivalDetail = festivalService.findOneById(festivalId);
@@ -58,7 +64,7 @@ public class FestivalUserController {
         return ResponseEntity.ok(responseDto);
     }
 
-    //축제명을 바탕으로 축제를 검색하는 기능
+    @Operation(summary = "축제명으로 축제를 검색하는 기능")
     @GetMapping
     public ResponseEntity<Page<FestivalListResponse>> searchFestival(
             @RequestParam(defaultValue = "0") int page,
@@ -69,6 +75,10 @@ public class FestivalUserController {
         return ResponseEntity.ok(festivalListResponses);
     }
 
+    @Operation(
+            summary = "내가 등록한 축제 조회",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @GetMapping("/my")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Page<FestivalListResponse>> getMyFestivals(
@@ -80,7 +90,10 @@ public class FestivalUserController {
         return ResponseEntity.ok(myFestivals);
     }
 
-    //자신이 올린 축제에 대해서만 수정 가능
+    @Operation(
+            summary = "내가 등록한 축제 수정",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PatchMapping("/{festivalId}")
     @PreAuthorize("hasRole('ROLE_FESTIVAL_MANAGER')")
     public ResponseEntity<ApiResponseDto<FestivalDetailResponseDto>> updateFestivalInfo(
@@ -93,7 +106,10 @@ public class FestivalUserController {
         return ResponseEntity.ok(responseDto);
     }
 
-    //자신이 올린 축제에 대해서만 삭제 가능
+    @Operation(
+            summary = "내가 등록한 축제 삭제",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @DeleteMapping("/{festivalId}")
     @PreAuthorize("hasRole('ROLE_FESTIVAL_MANAGER')")
     public ResponseEntity<Void> removeFestival(

--- a/src/main/java/kakao/festapick/review/controller/ReviewController.java
+++ b/src/main/java/kakao/festapick/review/controller/ReviewController.java
@@ -1,5 +1,8 @@
 package kakao.festapick.review.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import kakao.festapick.dto.ApiResponseDto;
@@ -20,10 +23,15 @@ import java.net.URI;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Tag(name = "Review API", description = "리뷰 도메인 API")
 public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @Operation(
+            summary = "리뷰 작성",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()") // 리뷰 작성은 인증 필요
     @PostMapping("/festivals/{festivalId}/reviews")
     public ResponseEntity<Void> createReview(
@@ -36,7 +44,7 @@ public class ReviewController {
         return ResponseEntity.created(URI.create("/api/reviews/" + reviewId)).build();
     }
 
-
+    @Operation(summary = "리뷰 조회 기능(특정 축제에 대한 리뷰 조회)")
     @GetMapping("/festivals/{festivalId}/reviews") // 리뷰 조회는 인증 불필요
     public ResponseEntity<Page<ReviewResponseDto>> getFestivalReviews(
             @RequestParam(defaultValue = "0", required = false) int page,
@@ -49,6 +57,10 @@ public class ReviewController {
                 HttpStatus.OK);
     }
 
+    @Operation(
+            summary = "내가 작성한 리뷰 조회(myReview)",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()") // 내 리뷰만 조회는 인증 필요
     @GetMapping("/reviews/my")
     public ResponseEntity<Page<ReviewResponseDto>> getMyReviews(
@@ -62,6 +74,7 @@ public class ReviewController {
                 HttpStatus.OK);
     }
 
+    @Operation(summary = "리뷰 조회(리뷰 단건 조회)")
     @GetMapping("/reviews/{reviewId}") // 리뷰 PK를 통한 것은 인증 불필요
     public ResponseEntity<ApiResponseDto<ReviewResponseDto>> getReview(@PathVariable Long reviewId) {
 
@@ -70,7 +83,10 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
-
+    @Operation(
+            summary = "내가 작성한 리뷰 수정",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()") // 리뷰 수정은 인증 필요
     @PutMapping("/reviews/{reviewId}")
     public ResponseEntity<Void> updateReview(
@@ -83,6 +99,10 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @Operation(
+            summary = "내가 작성한 리뷰 삭제",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()") // 리뷰 삭제는 인증 필요
     @DeleteMapping("/reviews/{reviewId}")
     public ResponseEntity<Void> removeReview(

--- a/src/main/java/kakao/festapick/wish/controller/WishController.java
+++ b/src/main/java/kakao/festapick/wish/controller/WishController.java
@@ -40,7 +40,6 @@ public class WishController {
             summary = "내가 누른 좋아요 목록 가져오기",
             security = @SecurityRequirement(name = "JWT")
     )
-    @PreAuthorize("isAuthenticated()")
     @GetMapping("/wishes/my")
     public ResponseEntity<Page<WishResponseDto>> getWishes(
             @AuthenticationPrincipal Long userId,
@@ -56,7 +55,6 @@ public class WishController {
             summary = "좋아요 삭제",
             security = @SecurityRequirement(name = "JWT")
     )
-    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/wishes/{wishId}")
     public ResponseEntity<Void> removeWish(
             @PathVariable Long wishId,

--- a/src/main/java/kakao/festapick/wish/controller/WishController.java
+++ b/src/main/java/kakao/festapick/wish/controller/WishController.java
@@ -1,5 +1,7 @@
 package kakao.festapick.wish.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.constraints.Max;
 import kakao.festapick.dto.ApiResponseDto;
 import kakao.festapick.wish.dto.WishResponseDto;
@@ -20,6 +22,10 @@ public class WishController {
 
     private final WishService wishService;
 
+    @Operation(
+            summary = "축제 좋아요 기능(좋아요 생성)",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/festivals/{festivalId}/wishes")
     public ResponseEntity<ApiResponseDto<WishResponseDto>> createWish(
@@ -30,6 +36,11 @@ public class WishController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    @Operation(
+            summary = "내가 누른 좋아요 목록 가져오기",
+            security = @SecurityRequirement(name = "JWT")
+    )
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/wishes/my")
     public ResponseEntity<Page<WishResponseDto>> getWishes(
             @AuthenticationPrincipal Long userId,
@@ -41,6 +52,11 @@ public class WishController {
                 HttpStatus.OK);
     }
 
+    @Operation(
+            summary = "좋아요 삭제",
+            security = @SecurityRequirement(name = "JWT")
+    )
+    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/wishes/{wishId}")
     public ResponseEntity<Void> removeWish(
             @PathVariable Long wishId,


### PR DESCRIPTION
close: #46 

- API 명세서 최신화를 까먹는 일이 빈번함으로 Swagger를 사용하는것이 좋을거 같습니다. 

- FE팀에서 사용이 가장 빈번한 domain(축제, 좋아요, 댓글)에 대해서만 우선적으로 적용해 두었습니다.

- 아직 개발 단계임으로 최대한 각 API에 대한 간단한 설명만 추가해 두었습니다.

- http://localhost:8080/swagger-ui/index.html 을 통해 명세서를 볼 수 있습니다.

- wish 도메인에서 삭제, 좋아요 목록 가져오기에 대해 로그인 상태를 확인하지 않아 `@PreAuthorize("isAuthenticated()")`을 추가해 주었습니다. (제가 로직을 잘못 이해하고 있는거라면 코멘트 남겨주시면 감사하겠습니다.)