### PR TITLE
채팅 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/kakao/festapick/ai/domain/RecommendationHistory.java
+++ b/src/main/java/kakao/festapick/ai/domain/RecommendationHistory.java
@@ -1,6 +1,7 @@
 package kakao.festapick.ai.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.user.domain.UserEntity;
 import lombok.AccessLevel;
@@ -17,7 +18,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-public class RecommendationHistory {
+public class RecommendationHistory extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/chat/controller/ChatController.java
+++ b/src/main/java/kakao/festapick/chat/controller/ChatController.java
@@ -1,5 +1,8 @@
 package kakao.festapick.chat.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kakao.festapick.chat.dto.ChatPayload;
 import kakao.festapick.chat.dto.ChatRoomResponseDto;
 import kakao.festapick.chat.service.ChatMessageService;
@@ -19,11 +22,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Chat API", description = "채팅 도메인 API")
 public class ChatController {
 
     private final ChatMessageService chatMessageService;
     private final ChatRoomService chatRoomService;
 
+    @Operation(
+            summary = "축제 아이디로 채팅방 아이디 조회",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/api/festivals/{festivalId}/chatRooms")
     public ResponseEntity<ApiResponseDto<Long>> getChatRoomId(
@@ -35,6 +43,10 @@ public class ChatController {
                 HttpStatus.OK);
     }
 
+    @Operation(
+            summary = "채팅방의 이전 메세지 불러오기",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/chatRooms/{chatRoomId}/messages")
     public ResponseEntity<Page<ChatPayload>> getPreviousMessages(
@@ -48,6 +60,10 @@ public class ChatController {
         return new ResponseEntity<>(payloads, HttpStatus.OK);
     }
 
+    @Operation(
+            summary = "채팅방 목록 보기",
+            security = @SecurityRequirement(name = "JWT")
+    )
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/chatRooms")
     public ResponseEntity<Page<ChatRoomResponseDto>> getChatRooms(

--- a/src/main/java/kakao/festapick/chat/controller/ChatController.java
+++ b/src/main/java/kakao/festapick/chat/controller/ChatController.java
@@ -1,33 +1,19 @@
 package kakao.festapick.chat.controller;
 
-import jakarta.validation.Valid;
-import java.security.Principal;
-import java.util.List;
 import kakao.festapick.chat.dto.ChatPayload;
 import kakao.festapick.chat.dto.ChatRoomResponseDto;
-import kakao.festapick.chat.dto.SendChatRequestDto;
 import kakao.festapick.chat.service.ChatMessageService;
-import kakao.festapick.chat.service.ChatParticipantService;
 import kakao.festapick.chat.service.ChatRoomService;
 import kakao.festapick.dto.ApiResponseDto;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/kakao/festapick/chat/controller/ChatController.java
+++ b/src/main/java/kakao/festapick/chat/controller/ChatController.java
@@ -34,13 +34,12 @@ public class ChatController {
     )
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/api/festivals/{festivalId}/chatRooms")
-    public ResponseEntity<ApiResponseDto<Long>> getChatRoomId(
+    public ResponseEntity<ApiResponseDto<ChatRoomResponseDto>> getChatRoomId(
             @PathVariable Long festivalId
     ) {
         ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getExistChatRoomOrMakeByFestivalId(
                 festivalId);
-        return new ResponseEntity<>(new ApiResponseDto<>(chatRoomResponseDto.roomId()),
-                HttpStatus.OK);
+        return new ResponseEntity<>(new ApiResponseDto<>(chatRoomResponseDto), HttpStatus.OK);
     }
 
     @Operation(

--- a/src/main/java/kakao/festapick/chat/controller/ChatStompController.java
+++ b/src/main/java/kakao/festapick/chat/controller/ChatStompController.java
@@ -2,29 +2,15 @@ package kakao.festapick.chat.controller;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
-import kakao.festapick.chat.dto.ChatPayload;
 import kakao.festapick.chat.dto.ChatRoomResponseDto;
-import kakao.festapick.chat.dto.SendChatRequestDto;
+import kakao.festapick.chat.dto.ChatRequestDto;
 import kakao.festapick.chat.service.ChatMessageService;
-import kakao.festapick.chat.service.ChatParticipantService;
 import kakao.festapick.chat.service.ChatRoomService;
-import kakao.festapick.dto.ApiResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.annotation.SubscribeMapping;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @Controller
 @RequiredArgsConstructor
@@ -36,7 +22,7 @@ public class ChatStompController {
     @MessageMapping("/{chatRoomId}/messages")
     public void sendChat(
             @DestinationVariable Long chatRoomId,
-            @Valid @Payload SendChatRequestDto requestDto,
+            @Valid @Payload ChatRequestDto requestDto,
             Principal principal
     ) {
         Long userId = Long.valueOf(principal.getName());

--- a/src/main/java/kakao/festapick/chat/controller/ChatStompController.java
+++ b/src/main/java/kakao/festapick/chat/controller/ChatStompController.java
@@ -32,7 +32,6 @@ public class ChatStompController {
 
     private final ChatMessageService chatMessageService;
     private final ChatRoomService chatRoomService;
-    private final ChatParticipantService chatParticipantService;
 
     @MessageMapping("/{chatRoomId}/messages")
     public void sendChat(
@@ -44,15 +43,4 @@ public class ChatStompController {
         ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getChatRoomByRoomId(chatRoomId);
         chatMessageService.sendChat(chatRoomResponseDto.roomId(), requestDto, userId);
     }
-
-    @SubscribeMapping("/{chatRoomId}/messages")
-    public void enterChatRoom(
-            @DestinationVariable Long chatRoomId,
-            Principal principal
-    ) {
-        Long userId = Long.valueOf(principal.getName());
-        ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getChatRoomByRoomId(chatRoomId);
-        chatParticipantService.enterChatRoom(userId, chatRoomResponseDto.roomId());
-    }
-
 }

--- a/src/main/java/kakao/festapick/chat/domain/ChatMessage.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatMessage.java
@@ -27,6 +27,8 @@ public class ChatMessage {
     @Size(max = 255)
     private String content;
 
+    private String imageUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id", nullable = false)
     private ChatRoom chatRoom;
@@ -38,13 +40,15 @@ public class ChatMessage {
     protected ChatMessage() {
     }
 
-    public ChatMessage(String content, ChatRoom chatRoom, UserEntity user) {
-        this(null, content, chatRoom, user);
+    public ChatMessage(String content, String imageUrl, ChatRoom chatRoom, UserEntity user) {
+        this(null, content, imageUrl, chatRoom, user);
     }
 
-    public ChatMessage(Long id, String content, ChatRoom chatRoom, UserEntity user) {
+    public ChatMessage(Long id, String content, String imageUrl, ChatRoom chatRoom,
+            UserEntity user) {
         this.id = id;
         this.content = content;
+        this.imageUrl = imageUrl;
         this.chatRoom = chatRoom;
         this.user = user;
     }
@@ -55,5 +59,9 @@ public class ChatMessage {
 
     public String getSenderProfileUrl() {
         return this.getUser().getProfileImageUrl();
+    }
+
+    public Long getUserId() {
+        return this.getUser().getId();
     }
 }

--- a/src/main/java/kakao/festapick/chat/domain/ChatMessage.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatMessage.java
@@ -11,13 +11,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.user.domain.UserEntity;
 import lombok.Getter;
 
 @Entity
 @Getter
 @Table(indexes = @Index(name = "idx_chat_message_chatroom_id_user_id", columnList = "chatroom_id, user_id"))
-public class ChatMessage {
+public class ChatMessage extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/chat/domain/ChatParticipant.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatParticipant.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.user.domain.UserEntity;
 import lombok.Getter;
 
@@ -22,7 +23,7 @@ import lombok.Getter;
         )
 },
         indexes = @Index(name = "idx_chat_participant_user_id_chatroom_id", columnList = "user_id, chatroom_id"))
-public class ChatParticipant {
+public class ChatParticipant extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/chat/domain/ChatRoom.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatRoom.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import kakao.festapick.festival.domain.Festival;
 import lombok.Getter;
@@ -25,8 +25,8 @@ public class ChatRoom {
     @Column(name = "roomName", nullable = false, length = 255)
     private String roomName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "festival_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "festival_id", nullable = false, unique = true)
     private Festival festival;
 
     protected ChatRoom() {

--- a/src/main/java/kakao/festapick/chat/domain/ChatRoom.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatRoom.java
@@ -10,13 +10,14 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.festival.domain.Festival;
 import lombok.Getter;
 
 @Entity
 @Getter
 @Table(indexes = @Index(name = "idx_chat_room_festival_id", columnList = "festival_id"))
-public class ChatRoom {
+public class ChatRoom extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/chat/dto/ChatPayload.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatPayload.java
@@ -5,14 +5,16 @@ import kakao.festapick.chat.domain.ChatMessage;
 
 public record ChatPayload(
         Long id,
+        Long userId,
         String senderName,
         String profileImgUrl,
         String content,
         String imageUrl
 ) {
 
-    public ChatPayload(ChatMessage chatMessage, String imageUrl) {
-        this(chatMessage.getId(), chatMessage.getSenderName(), chatMessage.getSenderProfileUrl(),
-                chatMessage.getContent(), imageUrl);
+    public ChatPayload(ChatMessage chatMessage) {
+        this(chatMessage.getId(), chatMessage.getUserId(), chatMessage.getSenderName(),
+                chatMessage.getSenderProfileUrl(),
+                chatMessage.getContent(), chatMessage.getImageUrl());
     }
 }

--- a/src/main/java/kakao/festapick/chat/dto/ChatPayload.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatPayload.java
@@ -1,10 +1,18 @@
 package kakao.festapick.chat.dto;
 
+import java.util.List;
+import kakao.festapick.chat.domain.ChatMessage;
+
 public record ChatPayload(
         Long id,
         String senderName,
         String profileImgUrl,
-        String content
+        String content,
+        List<String>imageUrls
 ) {
 
+    public ChatPayload(ChatMessage chatMessage, List<String> imageUrls) {
+        this(chatMessage.getId(), chatMessage.getSenderName(), chatMessage.getSenderProfileUrl(),
+                chatMessage.getContent(), imageUrls);
+    }
 }

--- a/src/main/java/kakao/festapick/chat/dto/ChatPayload.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatPayload.java
@@ -8,11 +8,11 @@ public record ChatPayload(
         String senderName,
         String profileImgUrl,
         String content,
-        List<String>imageUrls
+        String imageUrl
 ) {
 
-    public ChatPayload(ChatMessage chatMessage, List<String> imageUrls) {
+    public ChatPayload(ChatMessage chatMessage, String imageUrl) {
         this(chatMessage.getId(), chatMessage.getSenderName(), chatMessage.getSenderProfileUrl(),
-                chatMessage.getContent(), imageUrls);
+                chatMessage.getContent(), imageUrl);
     }
 }

--- a/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
@@ -9,4 +9,12 @@ public record ChatRequestDto(
         FileUploadRequest imageInfo
 ) {
 
+    public String getImageUrl() {
+        return imageInfo.presignedUrl();
+    }
+
+    public Long getTemporalFileId() {
+        return imageInfo.id();
+    }
+
 }

--- a/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
@@ -1,17 +1,12 @@
 package kakao.festapick.chat.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import java.util.ArrayList;
-import java.util.List;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 
 public record ChatRequestDto(
         @NotBlank
         String content,
-        List<FileUploadRequest> imageInfos
+        FileUploadRequest imageInfo
 ) {
 
-        public ChatRequestDto {
-                if (imageInfos == null) imageInfos = new ArrayList<>();
-        }
 }

--- a/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
@@ -5,16 +5,13 @@ import java.util.ArrayList;
 import java.util.List;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 
-public record SendChatRequestDto(
+public record ChatRequestDto(
         @NotBlank
         String content,
         List<FileUploadRequest> imageInfos
 ) {
-        public SendChatRequestDto (String content){
-                this(content, null);
-        }
 
-        public SendChatRequestDto {
+        public ChatRequestDto {
                 if (imageInfos == null) imageInfos = new ArrayList<>();
         }
 }

--- a/src/main/java/kakao/festapick/chat/dto/SendChatRequestDto.java
+++ b/src/main/java/kakao/festapick/chat/dto/SendChatRequestDto.java
@@ -1,10 +1,20 @@
 package kakao.festapick.chat.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
+import kakao.festapick.fileupload.dto.FileUploadRequest;
 
 public record SendChatRequestDto(
         @NotBlank
-        String content
+        String content,
+        List<FileUploadRequest> imageInfos
 ) {
+        public SendChatRequestDto (String content){
+                this(content, null);
+        }
 
+        public SendChatRequestDto {
+                if (imageInfos == null) imageInfos = new ArrayList<>();
+        }
 }

--- a/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
     private final JwtUtil jwtUtil;
@@ -84,7 +85,8 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
                 ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getChatRoomByRoomId(chatRoomId);
                 chatParticipantService.enterChatRoom(userId, chatRoomResponseDto.roomId());
             }
-            else if(!destination.equals("/queue/errors")){
+            else if(!destination.equals("/user/queue/errors")){
+                log.info(destination);
                 throw new WebSocketException(ExceptionCode.INVALID_DESTINATION);
             }
         }

--- a/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
@@ -84,7 +84,7 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
                 ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getChatRoomByRoomId(chatRoomId);
                 chatParticipantService.enterChatRoom(userId, chatRoomResponseDto.roomId());
             }
-            else {
+            else if(!destination.equals("/queue/errors")){
                 throw new WebSocketException(ExceptionCode.INVALID_DESTINATION);
             }
         }

--- a/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
@@ -12,6 +12,7 @@ import kakao.festapick.chat.service.ChatParticipantService;
 import kakao.festapick.chat.service.ChatRoomService;
 import kakao.festapick.global.exception.AuthenticationException;
 import kakao.festapick.global.exception.ExceptionCode;
+import kakao.festapick.global.exception.WebSocketException;
 import kakao.festapick.jwt.util.JwtUtil;
 import kakao.festapick.jwt.util.TokenType;
 import kakao.festapick.user.domain.UserEntity;
@@ -74,7 +75,7 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
                 throw new AuthenticationException(ExceptionCode.NO_LOGIN);
             }
             if (destination == null) {
-                return message;
+                throw new WebSocketException(ExceptionCode.MISSING_DESTINATION);
             }
             Matcher matcher = SUB_PATTERN.matcher(destination);
             if (matcher.matches()) {
@@ -82,6 +83,9 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
                 Long chatRoomId = Long.valueOf(matcher.group(1));
                 ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getChatRoomByRoomId(chatRoomId);
                 chatParticipantService.enterChatRoom(userId, chatRoomResponseDto.roomId());
+            }
+            else {
+                throw new WebSocketException(ExceptionCode.INVALID_DESTINATION);
             }
         }
 

--- a/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import kakao.festapick.chat.dto.ChatRoomResponseDto;
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Component;
 public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
     private static final Pattern CHATROOM_DEST_PATTERN = Pattern.compile("^/sub/(\\d+)/messages$");
+    private static final Pattern PUB_MESSAGE_DEST_PATTERN = Pattern.compile("^/pub/(\\d+)/messages$");
     private static final String USER_ERROR_DEST = "/user/queue/errors";
 
     private final JwtUtil jwtUtil;
@@ -46,52 +48,93 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor headerAccessor = MessageHeaderAccessor
                 .getAccessor(message, StompHeaderAccessor.class);
-        if (StompCommand.CONNECT.equals(headerAccessor.getCommand())) {
-            String authorization = headerAccessor.getFirstNativeHeader("Authorization");
-            if (authorization == null || !authorization.startsWith("Bearer ")) {
-                throw new AuthenticationException(ExceptionCode.ACCESS_TOKEN_NOT_EXIST);
-            }
 
-            String accessToken = authorization.split(" ")[1];
+        StompCommand command = Optional.ofNullable(headerAccessor.getCommand())
+                .orElseThrow(() -> new WebSocketException(ExceptionCode.MISSING_COMMAND));
 
-            if (!jwtUtil.validateToken(accessToken, TokenType.ACCESS_TOKEN)) {
-                throw new AuthenticationException(ExceptionCode.INVALID_ACCESS_TOKEN);
+        switch (command) {
+            case StompCommand.CONNECT -> handleConnect(headerAccessor);
+            case StompCommand.SUBSCRIBE -> handleSubscribe(headerAccessor);
+            case StompCommand.SEND -> handleSend(headerAccessor);
+            default -> {
+                // 그 외 command는 무시
             }
-
-            Claims claims = jwtUtil.getClaims(accessToken);
-            String identifier = claims.get("identifier").toString();
-
-            UserEntity findUser = userLowService.findByIdentifier(identifier);
-            Long userId = findUser.getId();
-            List<GrantedAuthority> authorities = Collections.singletonList(
-                    new SimpleGrantedAuthority("ROLE_" + findUser.getRoleType().name()));
-            Authentication auth = new UsernamePasswordAuthenticationToken(userId, null,
-                    authorities);
-            headerAccessor.setUser(auth);
-        } else if (StompCommand.SUBSCRIBE.equals(headerAccessor.getCommand())) {
-            Principal principal = headerAccessor.getUser();
-            String destination = headerAccessor.getDestination();
-            if (principal == null) {
-                throw new AuthenticationException(ExceptionCode.NO_LOGIN);
-            }
-            if (destination == null) {
-                throw new WebSocketException(ExceptionCode.MISSING_DESTINATION);
-            }
-            checkDestination(destination, principal);
         }
-
         return message;
     }
 
-    private void checkDestination(String destination, Principal principal) {
+    // 들어온 command가 Send인 경우
+    private void handleSend(StompHeaderAccessor headerAccessor) {
+        Optional.ofNullable(headerAccessor.getUser())
+                .orElseThrow(() -> new AuthenticationException(ExceptionCode.NO_LOGIN));
+        String destination = Optional.ofNullable(headerAccessor.getDestination())
+                .orElseThrow(() -> new WebSocketException(ExceptionCode.MISSING_DESTINATION));
+
+        //destination 확인
+        checkSendDestination(destination);
+    }
+
+    // 들어온 command가 Subscribe인 경우
+    private void handleSubscribe(StompHeaderAccessor headerAccessor) {
+        Principal principal = Optional.ofNullable(headerAccessor.getUser())
+                .orElseThrow(() -> new AuthenticationException(ExceptionCode.NO_LOGIN));
+        String destination = Optional.ofNullable(headerAccessor.getDestination())
+                .orElseThrow(() -> new WebSocketException(ExceptionCode.MISSING_DESTINATION));
+
+        //destination 확인
+        checkSubscribeDestination(destination, principal);
+    }
+
+    // 들어온 command가 Connect인 경우
+    private void handleConnect(StompHeaderAccessor headerAccessor) {
+        String authorization = headerAccessor.getFirstNativeHeader("Authorization");
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new AuthenticationException(ExceptionCode.ACCESS_TOKEN_NOT_EXIST);
+        }
+
+        String accessToken = authorization.split(" ")[1];
+
+        if (!jwtUtil.validateToken(accessToken, TokenType.ACCESS_TOKEN)) {
+            throw new AuthenticationException(ExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        Claims claims = jwtUtil.getClaims(accessToken);
+        String identifier = claims.get("identifier").toString();
+
+        UserEntity findUser = userLowService.findByIdentifier(identifier);
+        Long userId = findUser.getId();
+        List<GrantedAuthority> authorities = Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + findUser.getRoleType().name()));
+        Authentication auth = new UsernamePasswordAuthenticationToken(userId, null,
+                authorities);
+        headerAccessor.setUser(auth);
+    }
+
+    // 클라이언트에서 보낸 pub 메시지의 destination 검증
+    private void checkSendDestination(String destination) {
+        Matcher matcher = PUB_MESSAGE_DEST_PATTERN.matcher(destination);
+
+        // 채팅방 destination이 아니면 전부 예외처리
+        if (!matcher.matches()) {
+            throw new WebSocketException(ExceptionCode.INVALID_DESTINATION);
+        }
+    }
+
+    // 클라이언트에서 보낸 sub 메시지의 destination 검증
+    private void checkSubscribeDestination(String destination, Principal principal) {
         Matcher matcher = CHATROOM_DEST_PATTERN.matcher(destination);
+
+        // 채팅방 구독이거나
         if (matcher.matches()) {
             Long userId = Long.valueOf(principal.getName());
             Long chatRoomId = Long.valueOf(matcher.group(1));
             ChatRoomResponseDto chatRoomResponseDto = chatRoomService.getChatRoomByRoomId(chatRoomId);
             chatParticipantService.enterChatRoom(userId, chatRoomResponseDto.roomId());
-        } else if (!destination.equals(USER_ERROR_DEST)) {
-            throw new WebSocketException(ExceptionCode.INVALID_DESTINATION);
+        }
+
+        // 에러 메시지를 받기 위한 구독
+        else if (!destination.equals(USER_ERROR_DEST)) {
+            throw new WebSocketException(ExceptionCode.INVALID_DESTINATION); // 둘 다 아니면 예외 발생
         }
     }
 }

--- a/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/kakao/festapick/chat/interceptor/WebSocketAuthChannelInterceptor.java
@@ -71,7 +71,7 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
             Principal principal = headerAccessor.getUser();
             String destination = headerAccessor.getDestination();
             if (principal == null) {
-                throw new AuthenticationException(ExceptionCode.ACCESS_TOKEN_NOT_EXIST); //todo 적절한 예외
+                throw new AuthenticationException(ExceptionCode.NO_LOGIN);
             }
             if (destination == null) {
                 return message;

--- a/src/main/java/kakao/festapick/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/kakao/festapick/chat/repository/ChatMessageRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     @Query(value = "select c from ChatMessage c join fetch c.user u where c.chatRoom.id = :chatRoomId",

--- a/src/main/java/kakao/festapick/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/kakao/festapick/chat/repository/ChatMessageRepository.java
@@ -20,6 +20,9 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Query(value = "select c from ChatMessage c join fetch c.user u where c.chatRoom.id = :chatRoomId and c.user.id = :userId")
     List<ChatMessage> findAllByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 
+    @Query(value = "select c from ChatMessage c where c.user.id = :userId")
+    List<ChatMessage> findAllByUserId(Long userId);
+
     @Modifying(clearAutomatically = true)
     @Query("delete from ChatMessage c where c.chatRoom.id = :chatRoomId")
     void deleteByChatRoomId(Long chatRoomId);

--- a/src/main/java/kakao/festapick/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/kakao/festapick/chat/repository/ChatMessageRepository.java
@@ -17,9 +17,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Query(value = "select c from ChatMessage c join fetch c.user u where c.chatRoom.id = :chatRoomId")
     List<ChatMessage> findAllByChatRoomId(Long chatRoomId);
 
-    @Query(value = "select c from ChatMessage c join fetch c.user u where c.chatRoom.id = :chatRoomId and c.user.id = :userId")
-    List<ChatMessage> findAllByChatRoomIdAndUserId(Long chatRoomId, Long userId);
-
     @Query(value = "select c from ChatMessage c where c.user.id = :userId")
     List<ChatMessage> findAllByUserId(Long userId);
 

--- a/src/main/java/kakao/festapick/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/kakao/festapick/chat/repository/ChatParticipantRepository.java
@@ -7,9 +7,7 @@ import kakao.festapick.user.domain.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
 
     @Query(value = "select (count(cp) > 0) from ChatParticipant cp where cp.user= :user and cp.chatRoom= :chatRoom")

--- a/src/main/java/kakao/festapick/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/kakao/festapick/chat/repository/ChatRoomRepository.java
@@ -2,14 +2,10 @@ package kakao.festapick.chat.repository;
 
 import java.util.Optional;
 import kakao.festapick.chat.domain.ChatRoom;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query(value = "select c from ChatRoom c where c.festival.id = :festivalId")

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
@@ -32,10 +32,6 @@ public class ChatMessageLowService {
         return chatMessageRepository.findAllByUserId(userId);
     }
 
-    public List<ChatMessage> findAllByChatRoomIdAndUserId(Long chatRoomId, Long userId) {
-        return chatMessageRepository.findAllByChatRoomIdAndUserId(chatRoomId, userId);
-    }
-
     public void deleteByChatRoomId(Long chatRoomId) {
         chatMessageRepository.deleteByChatRoomId(chatRoomId);
     }

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
@@ -1,0 +1,51 @@
+package kakao.festapick.chat.service;
+
+import java.util.List;
+import kakao.festapick.chat.domain.ChatMessage;
+import kakao.festapick.chat.domain.ChatRoom;
+import kakao.festapick.chat.dto.ChatPayload;
+import kakao.festapick.chat.dto.SendChatRequestDto;
+import kakao.festapick.chat.repository.ChatMessageRepository;
+import kakao.festapick.chat.repository.ChatRoomRepository;
+import kakao.festapick.global.exception.ExceptionCode;
+import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageLowService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ChatMessage save(ChatMessage chatMessage) {
+        return chatMessageRepository.save(chatMessage);
+    }
+
+    public Page<ChatMessage> findByChatRoomId(Long chatRoomId, Pageable pageable) {
+        return chatMessageRepository.findByChatRoomId(chatRoomId, pageable);
+    }
+
+    public List<ChatMessage> findAllByChatRoomId(Long chatRoomId) {
+        return chatMessageRepository.findAllByChatRoomId(chatRoomId);
+    }
+
+    public List<ChatMessage> findAllByChatRoomIdAndUserId(Long chatRoomId, Long userId) {
+        return chatMessageRepository.findAllByChatRoomIdAndUserId(chatRoomId, userId);
+    }
+
+    public void deleteByChatRoomId(Long chatRoomId) {
+        chatMessageRepository.deleteByChatRoomId(chatRoomId);
+    }
+
+    public void deleteByUserId(Long userId) {
+        chatMessageRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
@@ -2,19 +2,10 @@ package kakao.festapick.chat.service;
 
 import java.util.List;
 import kakao.festapick.chat.domain.ChatMessage;
-import kakao.festapick.chat.domain.ChatRoom;
-import kakao.festapick.chat.dto.ChatPayload;
-import kakao.festapick.chat.dto.SendChatRequestDto;
 import kakao.festapick.chat.repository.ChatMessageRepository;
-import kakao.festapick.chat.repository.ChatRoomRepository;
-import kakao.festapick.global.exception.ExceptionCode;
-import kakao.festapick.global.exception.NotFoundEntityException;
-import kakao.festapick.user.domain.UserEntity;
-import kakao.festapick.user.service.UserLowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageLowService.java
@@ -37,6 +37,10 @@ public class ChatMessageLowService {
         return chatMessageRepository.findAllByChatRoomId(chatRoomId);
     }
 
+    public List<ChatMessage> findAllByUserId(Long userId) {
+        return chatMessageRepository.findAllByUserId(userId);
+    }
+
     public List<ChatMessage> findAllByChatRoomIdAndUserId(Long chatRoomId, Long userId) {
         return chatMessageRepository.findAllByChatRoomIdAndUserId(chatRoomId, userId);
     }

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageService.java
@@ -6,16 +6,13 @@ import java.util.List;
 import kakao.festapick.chat.domain.ChatMessage;
 import kakao.festapick.chat.domain.ChatRoom;
 import kakao.festapick.chat.dto.ChatPayload;
-import kakao.festapick.chat.dto.SendChatRequestDto;
+import kakao.festapick.chat.dto.ChatRequestDto;
 import kakao.festapick.fileupload.domain.DomainType;
 import kakao.festapick.fileupload.domain.FileEntity;
 import kakao.festapick.fileupload.domain.FileType;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 import kakao.festapick.fileupload.repository.TemporalFileRepository;
 import kakao.festapick.fileupload.service.FileService;
-import kakao.festapick.global.exception.ExceptionCode;
-import kakao.festapick.global.exception.NotFoundEntityException;
-import kakao.festapick.review.domain.Review;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.service.UserLowService;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +44,7 @@ public class ChatMessageService {
         });
     }
 
-    public void sendChat(Long chatRoomId, SendChatRequestDto requestDto, Long userId) {
+    public void sendChat(Long chatRoomId, ChatRequestDto requestDto, Long userId) {
         UserEntity sender = userLowService.findById(userId);
         String senderName = sender.getUsername();
         String profileImgUrl = sender.getProfileImageUrl();

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageService.java
@@ -34,17 +34,6 @@ public class ChatMessageService {
     private final FileService fileService;
     private final TemporalFileRepository temporalFileRepository;
 
-    // 채팅 메시지 엔티티와 url 매핑
-    private static void chatMessageIdAndUrlMapping(List<FileEntity> files,
-            HashMap<Long, List<String>> imageUrls) {
-        files.forEach(file -> {
-            if (!imageUrls.containsKey(file.getDomainId())) {
-                imageUrls.put(file.getDomainId(), new ArrayList<>());
-            }
-            imageUrls.get(file.getDomainId()).add(file.getUrl());
-        });
-    }
-
     // 채팅 메시지 보내기
     public void sendChat(Long chatRoomId, ChatRequestDto requestDto, Long userId) {
         UserEntity sender = userLowService.findById(userId);
@@ -84,7 +73,8 @@ public class ChatMessageService {
                 .stream().map(ChatMessage::getId).toList();
 
         chatMessageLowService.deleteByUserId(userId);
-        fileService.deleteByDomainIds(chatMessageIds, DomainType.CHAT); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
+        fileService.deleteByDomainIds(chatMessageIds,
+                DomainType.CHAT); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
     }
 
     // 파일 저장
@@ -94,7 +84,8 @@ public class ChatMessageService {
 
         if (imageInfos != null) {
             imageInfos.forEach(imageInfo -> {
-                files.add(new FileEntity(imageInfo.presignedUrl(), FileType.IMAGE, DomainType.CHAT, id));
+                files.add(new FileEntity(imageInfo.presignedUrl(), FileType.IMAGE, DomainType.CHAT,
+                        id));
                 temporalFileIds.add(imageInfo.id());
             });
         }
@@ -115,5 +106,16 @@ public class ChatMessageService {
                 .toList();
 
         return fileService.findAllFileEntityByDomain(domainIds, DomainType.CHAT);
+    }
+
+    // 채팅 메시지 엔티티와 url 매핑
+    private void chatMessageIdAndUrlMapping(List<FileEntity> files,
+            HashMap<Long, List<String>> imageUrls) {
+        files.forEach(file -> {
+            if (!imageUrls.containsKey(file.getDomainId())) {
+                imageUrls.put(file.getDomainId(), new ArrayList<>());
+            }
+            imageUrls.get(file.getDomainId()).add(file.getUrl());
+        });
     }
 }

--- a/src/main/java/kakao/festapick/chat/service/ChatMessageService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatMessageService.java
@@ -1,11 +1,21 @@
 package kakao.festapick.chat.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import kakao.festapick.chat.domain.ChatMessage;
 import kakao.festapick.chat.domain.ChatRoom;
 import kakao.festapick.chat.dto.ChatPayload;
 import kakao.festapick.chat.dto.SendChatRequestDto;
+import kakao.festapick.fileupload.domain.DomainType;
+import kakao.festapick.fileupload.domain.FileEntity;
+import kakao.festapick.fileupload.domain.FileType;
+import kakao.festapick.fileupload.dto.FileUploadRequest;
+import kakao.festapick.fileupload.repository.TemporalFileRepository;
+import kakao.festapick.fileupload.service.FileService;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.review.domain.Review;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.service.UserLowService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +34,18 @@ public class ChatMessageService {
     private final UserLowService userLowService;
     private final ChatMessageLowService chatMessageLowService;
     private final ChatRoomLowService chatRoomLowService;
+    private final FileService fileService;
+    private final TemporalFileRepository temporalFileRepository;
+
+    private static void chatMessageIdAndUrlMapping(List<FileEntity> files,
+            HashMap<Long, List<String>> imageUrls) {
+        files.forEach(file -> {
+            if (!imageUrls.containsKey(file.getDomainId())) {
+                imageUrls.put(file.getDomainId(), new ArrayList<>());
+            }
+            imageUrls.get(file.getDomainId()).add(file.getUrl());
+        });
+    }
 
     public void sendChat(Long chatRoomId, SendChatRequestDto requestDto, Long userId) {
         UserEntity sender = userLowService.findById(userId);
@@ -34,8 +56,9 @@ public class ChatMessageService {
 
         ChatMessage chatMessage = new ChatMessage(requestDto.content(), chatRoom, sender);
         ChatMessage savedMessage = chatMessageLowService.save(chatMessage);
+        List<String> urls = saveFiles(requestDto.imageInfos(), savedMessage.getId());
         ChatPayload payload = new ChatPayload(savedMessage.getId(), senderName,
-                profileImgUrl, requestDto.content());
+                profileImgUrl, requestDto.content(), urls);
 
         webSocket.convertAndSend("/sub/" + chatRoom.getId() + "/messages", payload);
     }
@@ -43,8 +66,48 @@ public class ChatMessageService {
     public Page<ChatPayload> getPreviousMessages(Long chatRoomId, Pageable pageable) {
         Page<ChatMessage> previousMessages = chatMessageLowService.findByChatRoomId(chatRoomId,
                 pageable);
-        return previousMessages.map(chatMessage -> new ChatPayload(chatMessage.getId(),
-                chatMessage.getSenderName(),
-                chatMessage.getSenderProfileUrl(), chatMessage.getContent()));
+
+        List<FileEntity> files = findFilesByChatMessages(previousMessages);
+
+        HashMap<Long, List<String>> imageUrls = new HashMap<>();
+        chatMessageIdAndUrlMapping(files, imageUrls);
+
+        return previousMessages.map(chatMessage -> new ChatPayload(chatMessage,
+                imageUrls.getOrDefault(chatMessage.getId(), List.of())));
+    }
+
+    public void deleteChatMessagesByUserId(Long userId) {
+        List<Long> chatMessageIds = chatMessageLowService.findAllByUserId(userId)
+                .stream().map(ChatMessage::getId).toList();
+
+        chatMessageLowService.deleteByUserId(userId);
+        fileService.deleteByDomainIds(chatMessageIds, DomainType.CHAT); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
+    }
+
+    private List<String> saveFiles(List<FileUploadRequest> imageInfos, Long id) {
+        List<FileEntity> files = new ArrayList<>();
+        List<Long> temporalFileIds = new ArrayList<>();
+
+        if (imageInfos != null) {
+            imageInfos.forEach(imageInfo -> {
+                files.add(new FileEntity(imageInfo.presignedUrl(), FileType.IMAGE, DomainType.CHAT, id));
+                temporalFileIds.add(imageInfo.id());
+            });
+        }
+
+        if (!files.isEmpty()) {
+            fileService.saveAll(files);
+        }
+        temporalFileRepository.deleteByIds(temporalFileIds);
+
+        return files.stream().map(FileEntity::getUrl).toList();
+    }
+
+    private List<FileEntity> findFilesByChatMessages(Page<ChatMessage> chatMessages) {
+        List<Long> domainIds = chatMessages.stream()
+                .map(ChatMessage::getId)
+                .toList();
+
+        return fileService.findAllFileEntityByDomain(domainIds, DomainType.CHAT);
     }
 }

--- a/src/main/java/kakao/festapick/chat/service/ChatParticipantLowService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatParticipantLowService.java
@@ -1,0 +1,42 @@
+package kakao.festapick.chat.service;
+
+import java.util.List;
+import kakao.festapick.chat.domain.ChatParticipant;
+import kakao.festapick.chat.domain.ChatRoom;
+import kakao.festapick.chat.repository.ChatParticipantRepository;
+import kakao.festapick.chat.repository.ChatRoomRepository;
+import kakao.festapick.global.exception.ExceptionCode;
+import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.user.domain.UserEntity;
+import kakao.festapick.user.service.UserLowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatParticipantLowService {
+
+    private final ChatParticipantRepository chatParticipantRepository;
+
+    public ChatParticipant save(ChatParticipant chatParticipant) {
+        return chatParticipantRepository.save(chatParticipant);
+    }
+
+    public boolean existsByUserAndChatRoom(UserEntity user, ChatRoom chatRoom) {
+        return chatParticipantRepository.existsByUserAndChatRoom(user, chatRoom);
+    }
+
+    public List<ChatParticipant> findByChatRoomId(Long chatRooomId) {
+        return chatParticipantRepository.findByChatRoomId(chatRooomId);
+    }
+
+    public void deleteByChatRoomId(Long chatRoomId) {
+        chatParticipantRepository.deleteByChatRoomId(chatRoomId);
+    }
+
+    public void deleteByUserId(Long userId) {
+        chatParticipantRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/kakao/festapick/chat/service/ChatParticipantService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatParticipantService.java
@@ -17,6 +17,7 @@ public class ChatParticipantService {
     private final ChatRoomLowService chatRoomLowService;
     private final UserLowService userLowService;
 
+    //채팅룸 입장 시 Chat Participant에 저장
     public void enterChatRoom(Long userId, Long roomId) {
         ChatRoom chatRoom = chatRoomLowService.findByRoomId(roomId);
 

--- a/src/main/java/kakao/festapick/chat/service/ChatParticipantService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatParticipantService.java
@@ -2,10 +2,6 @@ package kakao.festapick.chat.service;
 
 import kakao.festapick.chat.domain.ChatParticipant;
 import kakao.festapick.chat.domain.ChatRoom;
-import kakao.festapick.chat.repository.ChatParticipantRepository;
-import kakao.festapick.chat.repository.ChatRoomRepository;
-import kakao.festapick.global.exception.ExceptionCode;
-import kakao.festapick.global.exception.NotFoundEntityException;
 import kakao.festapick.user.domain.UserEntity;
 import kakao.festapick.user.service.UserLowService;
 import lombok.RequiredArgsConstructor;
@@ -17,19 +13,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ChatParticipantService {
 
-    private final ChatParticipantRepository chatParticipantRepository;
-    private final ChatRoomRepository chatRoomRepository;
+    private final ChatParticipantLowService chatParticipantLowService;
+    private final ChatRoomLowService chatRoomLowService;
     private final UserLowService userLowService;
 
     public void enterChatRoom(Long userId, Long roomId) {
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.CHATROOM_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomLowService.findByRoomId(roomId);
 
         UserEntity user = userLowService.findById(userId);
 
-        if (!chatParticipantRepository.existsByUserAndChatRoom(user, chatRoom)) {
+        if (!chatParticipantLowService.existsByUserAndChatRoom(user, chatRoom)) {
             ChatParticipant chatParticipant = new ChatParticipant(user, chatRoom);
-            chatParticipantRepository.save(chatParticipant);
+            chatParticipantLowService.save(chatParticipant);
         }
     }
 }

--- a/src/main/java/kakao/festapick/chat/service/ChatRoomLowService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatRoomLowService.java
@@ -1,0 +1,46 @@
+package kakao.festapick.chat.service;
+
+import java.util.Optional;
+import kakao.festapick.chat.domain.ChatRoom;
+import kakao.festapick.chat.dto.ChatRoomResponseDto;
+import kakao.festapick.chat.repository.ChatMessageRepository;
+import kakao.festapick.chat.repository.ChatParticipantRepository;
+import kakao.festapick.chat.repository.ChatRoomRepository;
+import kakao.festapick.festival.domain.Festival;
+import kakao.festapick.festival.repository.FestivalRepository;
+import kakao.festapick.global.exception.ExceptionCode;
+import kakao.festapick.global.exception.NotFoundEntityException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomLowService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatRoom save(ChatRoom chatRoom) {
+        return chatRoomRepository.save(chatRoom);
+    }
+
+    public Optional<ChatRoom> findByFestivalId(Long festivalId) {
+        return chatRoomRepository.findByFestivalId(festivalId);
+    }
+
+    public ChatRoom findByRoomId(Long roomId) {
+        return chatRoomRepository.findByRoomId(roomId)
+                .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.CHATROOM_NOT_FOUND));
+    }
+
+    public void deleteById(Long chatRoomId) {
+        chatRoomRepository.deleteById(chatRoomId);
+    }
+
+    public Page<ChatRoom> findAll(Pageable pageable) {
+        return chatRoomRepository.findAll(pageable);
+    }
+}

--- a/src/main/java/kakao/festapick/chat/service/ChatRoomService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatRoomService.java
@@ -29,35 +29,43 @@ public class ChatRoomService {
     private final ChatMessageLowService chatMessageLowService;
     private final FileService fileService;
 
+    // 축제에 해당하는 채팅방이 존재하는지 확인 후 채팅방 정보 반환, 없으면 생성 후 반환
     public ChatRoomResponseDto getExistChatRoomOrMakeByFestivalId(Long festivalId) {
         Optional<ChatRoom> chatRoomOptional = chatRoomLowService.findByFestivalId(festivalId);
+        // 조회 결과 채팅방이 없으면 축제에 해당하는 채팅망 생성후 반환
         if (chatRoomOptional.isEmpty()) {
             Festival festival = festivalLowService.findFestivalById(festivalId);
             ChatRoom newChatRoom = new ChatRoom(festival.getTitle() + " 채팅방", festival);
             ChatRoom savedChatRoom = chatRoomLowService.save(newChatRoom);
             return new ChatRoomResponseDto(savedChatRoom.getId(),
                     savedChatRoom.getRoomName(), savedChatRoom.getFestivalId());
-        } else {
+        }
+        // 있으면 반환
+        else {
             ChatRoom findChatRoom = chatRoomOptional.get();
             return new ChatRoomResponseDto(findChatRoom.getId(),
                     findChatRoom.getRoomName(), findChatRoom.getFestivalId());
         }
     }
 
+    // 채팅방 id로 채팅방 정보 조회
     public ChatRoomResponseDto getChatRoomByRoomId(Long roomId) {
         ChatRoom chatRoom = chatRoomLowService.findByRoomId(roomId);
         return new ChatRoomResponseDto(chatRoom.getId(), chatRoom.getRoomName(),
                 chatRoom.getFestivalId());
     }
 
+    // 현재 존재하는 채팅방 정보 목록 조회 (pageable)
     public Page<ChatRoomResponseDto> getChatRooms(Pageable pageable) {
         Page<ChatRoom> chatRooms = chatRoomLowService.findAll(pageable);
         return chatRooms.map(chatRoom -> new ChatRoomResponseDto(chatRoom.getId(),
                 chatRoom.getRoomName(), chatRoom.getFestivalId()));
     }
 
+    // 축제 id로 해당 채팅방 삭제
     public void deleteChatRoomByfestivalIdIfExist(Long festivalId) {
         Optional<ChatRoom> chatRoom = chatRoomLowService.findByFestivalId(festivalId);
+        // 조회 결과 채팅방이 있으면 연관 엔티티 제거 후 채팅방 삭제
         if (chatRoom.isPresent()) {
             Long chatRoomId = chatRoom.get().getId();
             deleteRelatedEntity(chatRoomId);
@@ -65,6 +73,7 @@ public class ChatRoomService {
         }
     }
 
+    // 연관 엔티티 (채팅방 내 채팅 메시지, 채팅방 참여자) 정리
     private void deleteRelatedEntity(Long chatRoomId) {
         chatParticipantLowService.deleteByChatRoomId(chatRoomId);
         chatMessageLowService.deleteByChatRoomId(chatRoomId);

--- a/src/main/java/kakao/festapick/chat/service/ChatRoomService.java
+++ b/src/main/java/kakao/festapick/chat/service/ChatRoomService.java
@@ -1,12 +1,17 @@
 package kakao.festapick.chat.service;
 
+import java.util.List;
 import java.util.Optional;
+import kakao.festapick.chat.domain.ChatMessage;
 import kakao.festapick.chat.domain.ChatRoom;
 import kakao.festapick.chat.dto.ChatRoomResponseDto;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.service.FestivalLowService;
+import kakao.festapick.fileupload.domain.DomainType;
+import kakao.festapick.fileupload.service.FileService;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.review.domain.Review;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +27,7 @@ public class ChatRoomService {
     private final FestivalLowService festivalLowService;
     private final ChatParticipantLowService chatParticipantLowService;
     private final ChatMessageLowService chatMessageLowService;
+    private final FileService fileService;
 
     public ChatRoomResponseDto getExistChatRoomOrMakeByFestivalId(Long festivalId) {
         Optional<ChatRoom> chatRoomOptional = chatRoomLowService.findByFestivalId(festivalId);
@@ -62,5 +68,9 @@ public class ChatRoomService {
     private void deleteRelatedEntity(Long chatRoomId) {
         chatParticipantLowService.deleteByChatRoomId(chatRoomId);
         chatMessageLowService.deleteByChatRoomId(chatRoomId);
+
+        List<Long> chatMessageIds = chatMessageLowService.findAllByChatRoomId(chatRoomId)
+                .stream().map(ChatMessage::getId).toList();
+        fileService.deleteByDomainIds(chatMessageIds, DomainType.CHAT); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
     }
 }

--- a/src/main/java/kakao/festapick/config/WebSocketConfig.java
+++ b/src/main/java/kakao/festapick/config/WebSocketConfig.java
@@ -25,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/sub");
-        registry.setApplicationDestinationPrefixes("/pub", "/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
     }
 
     @Override

--- a/src/main/java/kakao/festapick/domain/BaseTimeEntity.java
+++ b/src/main/java/kakao/festapick/domain/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package kakao.festapick.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+}

--- a/src/main/java/kakao/festapick/festival/domain/Festival.java
+++ b/src/main/java/kakao/festapick/festival/domain/Festival.java
@@ -1,6 +1,7 @@
 package kakao.festapick.festival.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.festival.dto.FestivalCustomRequestDto;
 import kakao.festapick.festival.dto.FestivalRequestDto;
 import kakao.festapick.festival.dto.FestivalUpdateRequestDto;
@@ -17,7 +18,7 @@ import java.time.LocalDate;
 @Getter
 @Slf4j
 @Table(indexes = @Index(name = "idx_festival_area_state_startdate_id", columnList= "areaCode, state, startDate, id"))
-public class Festival {
+public class Festival extends BaseTimeEntity {
 
     private static String defaultImage;
 

--- a/src/main/java/kakao/festapick/fileupload/domain/DomainType.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/DomainType.java
@@ -2,6 +2,5 @@ package kakao.festapick.fileupload.domain;
 
 public enum DomainType {
     REVIEW,
-    FESTIVAL,
-    CHAT
+    FESTIVAL
 }

--- a/src/main/java/kakao/festapick/fileupload/domain/DomainType.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/DomainType.java
@@ -2,5 +2,6 @@ package kakao.festapick.fileupload.domain;
 
 public enum DomainType {
     REVIEW,
-    FESTIVAL
+    FESTIVAL,
+    CHAT
 }

--- a/src/main/java/kakao/festapick/fileupload/domain/FileEntity.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/FileEntity.java
@@ -1,6 +1,7 @@
 package kakao.festapick.fileupload.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,7 +18,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-public class FileEntity {
+public class FileEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/fileupload/domain/TemporalFile.java
+++ b/src/main/java/kakao/festapick/fileupload/domain/TemporalFile.java
@@ -1,6 +1,7 @@
 package kakao.festapick.fileupload.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TemporalFile {
+public class TemporalFile extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
+++ b/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
@@ -34,7 +34,11 @@ public enum ExceptionCode {
     FESTIVAL_BAD_IMAGE("이미 등록되어 있는 이미지 입니다."),
 
     //INTERNAL_SERVER_ERROR
-    FAST_API_CONNECTION_ERROR("AI 추천 기능 호출 실패");
+    FAST_API_CONNECTION_ERROR("AI 추천 기능 호출 실패"),
+
+    //WEB_SOCKET_EXCEPTION
+    MISSING_DESTINATION("destination이 없습니다."),
+    INVALID_DESTINATION("유효하지 않은 destination입니다.");
 
     private final String errorMessage;
 

--- a/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
+++ b/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
     INVALID_REFRESH_TOKEN("리프레시 토큰이 유효하지 않습니다."),
     INVALID_ACCESS_TOKEN("액세스 토큰이 유효하지 않습니다."),
     ACCESS_TOKEN_NOT_EXIST("액세스 토큰이 존재하지 않습니다."),
+    NO_LOGIN("유효한 로그인이 아닙니다."),
 
     //NotFound
     FESTIVAL_NOT_FOUND("존재하지 않는 축제입니다."),

--- a/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
+++ b/src/main/java/kakao/festapick/global/exception/ExceptionCode.java
@@ -38,6 +38,7 @@ public enum ExceptionCode {
 
     //WEB_SOCKET_EXCEPTION
     MISSING_DESTINATION("destination이 없습니다."),
+    MISSING_COMMAND("command가 없습니다."),
     INVALID_DESTINATION("유효하지 않은 destination입니다.");
 
     private final String errorMessage;

--- a/src/main/java/kakao/festapick/global/exception/WebSocketException.java
+++ b/src/main/java/kakao/festapick/global/exception/WebSocketException.java
@@ -1,0 +1,14 @@
+package kakao.festapick.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class WebSocketException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public WebSocketException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getErrorMessage());
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/src/main/java/kakao/festapick/jwt/domain/RefreshToken.java
+++ b/src/main/java/kakao/festapick/jwt/domain/RefreshToken.java
@@ -1,6 +1,7 @@
 package kakao.festapick.jwt.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.user.domain.UserEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kakao/festapick/review/domain/Review.java
+++ b/src/main/java/kakao/festapick/review/domain/Review.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.user.domain.UserEntity;
 import lombok.Getter;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @Getter
 @Check(constraints = "score >= 1 AND score <= 5")
 @EntityListeners(AuditingEntityListener.class)
-public class Review {
+public class Review extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,13 +42,6 @@ public class Review {
     @Min(1)
     @Max(5)
     private Integer score;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdDate;
-
-    @LastModifiedDate
-    private LocalDateTime updatedDate;
 
     protected Review() {
     }

--- a/src/main/java/kakao/festapick/review/service/ReviewService.java
+++ b/src/main/java/kakao/festapick/review/service/ReviewService.java
@@ -45,10 +45,12 @@ public class ReviewService {
     private final S3Service s3Service;
 
 
+    // 리뷰 생성 기능
     public Long createReview(Long festivalId, ReviewRequestDto requestDto, Long userId) {
         Festival festival = festivalLowService.findFestivalById(festivalId);
         UserEntity user = userLowService.findById(userId);
 
+        // 유저가 해당 축제에 남긴 리뷰가 이미 있으면 예외 반환
         if (reviewLowService.existsByUserIdAndFestivalId(user.getId(), festivalId)) {
             throw new DuplicateEntityException(ExceptionCode.REVIEW_DUPLICATE);
         }
@@ -61,6 +63,7 @@ public class ReviewService {
         return saved.getId();
     }
 
+    // 축제에 대한 리뷰 조회 (pageable)
     public Page<ReviewResponseDto> getFestivalReviews(Long festivalId, Pageable pageable) {
         Page<Review> reviews = reviewLowService.findByFestivalIdWithAll(festivalId, pageable);
 
@@ -77,6 +80,7 @@ public class ReviewService {
         );
     }
 
+    // 리뷰 id로 리뷰 단건 조회
     public ReviewResponseDto getReview(Long reviewId) {
         Review review = reviewLowService.findById(reviewId);
 
@@ -91,6 +95,7 @@ public class ReviewService {
 
     }
 
+    // 내가 작성한 리뷰 조회
     public Page<ReviewResponseDto> getMyReviews(Long userId, Pageable pageable) {
         Page<Review> reviews = reviewLowService.findByUserIdWithAll(userId, pageable);
 
@@ -113,6 +118,7 @@ public class ReviewService {
      * 4. 기존 리뷰에 존재하지 않는 파일이지만 ReviewRequestDto에 존재한다면 추가를 해야한다.
      */
 
+    // 리뷰 수정 기능
     public void updateReview(Long reviewId, @Valid ReviewRequestDto requestDto, Long userId) {
         Review review = reviewLowService.findByUserIdAndId(userId, reviewId);
 
@@ -161,8 +167,10 @@ public class ReviewService {
     }
 
 
+    // 작성한 리뷰 삭제
     public void removeReview(Long reviewId, Long userId) {
 
+        // 해당하는 리뷰 가 없는 경우 예외 반환
         if (reviewLowService.deleteByUserIdAndId(userId, reviewId) == 0) {
             throw new NotFoundEntityException(ExceptionCode.REVIEW_NOT_FOUND);
         }
@@ -170,6 +178,7 @@ public class ReviewService {
         fileService.deleteByDomainId(reviewId, DomainType.REVIEW); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
     }
 
+    // 축제에 작성된 리뷰 전체 삭제
     public void deleteReviewByFestivalId(Long festivalId) {
 
         List<Long> reviewIds = reviewLowService.findByFestivalId(festivalId)
@@ -180,6 +189,7 @@ public class ReviewService {
         fileService.deleteByDomainIds(reviewIds, DomainType.REVIEW); // s3 파일 삭제를 동반하기 때문에 마지막에 호출
     }
 
+    // 유저가 작성한 리뷰 전체 삭제
     public void deleteReviewByUserId(Long userId) {
 
         List<Long> reviewIds = reviewLowService.findByUserId(userId)

--- a/src/main/java/kakao/festapick/user/domain/UserEntity.java
+++ b/src/main/java/kakao/festapick/user/domain/UserEntity.java
@@ -1,6 +1,7 @@
 package kakao.festapick.user.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.jwt.domain.RefreshToken;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Table(name = "users")
 @Getter
-public class UserEntity {
+public class UserEntity extends BaseTimeEntity {
 
     private static String defaultImage;
 
@@ -49,13 +50,6 @@ public class UserEntity {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private RefreshToken refreshToken;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdDate;
-
-    @LastModifiedDate
-    private LocalDateTime updatedDate;
 
     public UserEntity(String identifier, String email, String username, UserRoleType userRoleType, SocialType socialType) {
         this.identifier = identifier;

--- a/src/main/java/kakao/festapick/user/service/UserService.java
+++ b/src/main/java/kakao/festapick/user/service/UserService.java
@@ -1,7 +1,7 @@
 package kakao.festapick.user.service;
 
 import jakarta.servlet.http.HttpServletResponse;
-import kakao.festapick.chat.service.ChatMessageLowService;
+import kakao.festapick.chat.service.ChatMessageService;
 import kakao.festapick.chat.service.ChatParticipantLowService;
 import kakao.festapick.ai.service.RecommendationHistoryLowService;
 import kakao.festapick.festival.service.FestivalService;
@@ -36,7 +36,7 @@ public class UserService {
     private final S3Service s3Service;
     private final TemporalFileRepository temporalFileRepository;
     private final ChatParticipantLowService chatParticipantLowService;
-    private final ChatMessageLowService chatMessageLowService;
+    private final ChatMessageService chatMessageService;
 
 
     public void withDraw(Long userId, HttpServletResponse response) {
@@ -93,7 +93,7 @@ public class UserService {
         recommendationHistoryLowService.deleteByUserId(findUser.getId());
         wishLowService.deleteByUserId(findUser.getId());
         chatParticipantLowService.deleteByUserId(findUser.getId());
-        chatMessageLowService.deleteByUserId(findUser.getId());
+        chatMessageService.deleteChatMessagesByUserId(findUser.getId());
         reviewService.deleteReviewByUserId(findUser.getId());
         festivalService.deleteFestivalByManagerId(findUser.getId());
     }

--- a/src/main/java/kakao/festapick/user/service/UserService.java
+++ b/src/main/java/kakao/festapick/user/service/UserService.java
@@ -1,8 +1,8 @@
 package kakao.festapick.user.service;
 
 import jakarta.servlet.http.HttpServletResponse;
-import kakao.festapick.chat.repository.ChatMessageRepository;
-import kakao.festapick.chat.repository.ChatParticipantRepository;
+import kakao.festapick.chat.service.ChatMessageLowService;
+import kakao.festapick.chat.service.ChatParticipantLowService;
 import kakao.festapick.festival.service.FestivalService;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 import kakao.festapick.fileupload.repository.TemporalFileRepository;
@@ -14,8 +14,6 @@ import kakao.festapick.user.domain.UserRoleType;
 import kakao.festapick.user.dto.UserResponseDto;
 import kakao.festapick.user.dto.UserResponseDtoForAdmin;
 import kakao.festapick.user.dto.UserSearchCond;
-import kakao.festapick.user.repository.QUserRepository;
-import kakao.festapick.wish.repository.WishRepository;
 import kakao.festapick.wish.service.WishLowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,8 +33,8 @@ public class UserService {
     private final CookieComponent cookieComponent;
     private final S3Service s3Service;
     private final TemporalFileRepository temporalFileRepository;
-    private final ChatParticipantRepository chatParticipantRepository;
-    private final ChatMessageRepository chatMessageRepository;
+    private final ChatParticipantLowService chatParticipantLowService;
+    private final ChatMessageLowService chatMessageLowService;
 
 
     public void withDraw(Long userId, HttpServletResponse response) {
@@ -91,8 +89,8 @@ public class UserService {
 
     private void deleteRelatedEntity(UserEntity findUser) {
         wishLowService.deleteByUserId(findUser.getId());
-        chatParticipantRepository.deleteByUserId(findUser.getId());
-        chatMessageRepository.deleteByUserId(findUser.getId());
+        chatParticipantLowService.deleteByUserId(findUser.getId());
+        chatMessageLowService.deleteByUserId(findUser.getId());
         reviewService.deleteReviewByUserId(findUser.getId());
         festivalService.deleteFestivalByManagerId(findUser.getId());
     }

--- a/src/main/java/kakao/festapick/wish/domain/Wish.java
+++ b/src/main/java/kakao/festapick/wish/domain/Wish.java
@@ -1,6 +1,7 @@
 package kakao.festapick.wish.domain;
 
 import jakarta.persistence.*;
+import kakao.festapick.domain.BaseTimeEntity;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.user.domain.UserEntity;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-public class Wish {
+public class Wish extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,10 +27,6 @@ public class Wish {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id", nullable = false)
     private Festival festival;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdDate;
 
     protected Wish() {
     }

--- a/src/main/java/kakao/festapick/wish/domain/Wish.java
+++ b/src/main/java/kakao/festapick/wish/domain/Wish.java
@@ -7,9 +7,11 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class Wish {
 
     @Id

--- a/src/main/java/kakao/festapick/wish/service/WishService.java
+++ b/src/main/java/kakao/festapick/wish/service/WishService.java
@@ -25,11 +25,13 @@ public class WishService {
     private final UserLowService userLowService;
     private final FestivalLowService festivalLowService;
 
+    // 좋아요 등록
     @Transactional
     public WishResponseDto createWish(Long festivalId, Long userId) {
         Festival festival = festivalLowService.findFestivalById(festivalId);
         UserEntity user = userLowService.findById(userId);
 
+        // 이미 좋아요를 했으면 예외 반환
         wishLowService.findByUserIdAndFestivalId(userId, festivalId)
                 .ifPresent(w -> {
                     throw new DuplicateEntityException(ExceptionCode.WISH_DUPLICATE);
@@ -42,6 +44,7 @@ public class WishService {
                 festivalResponseDto.areaCode());
     }
 
+    // 유저의 좋아요 반환
     public Page<WishResponseDto> getWishes(Long userId, Pageable pageable) {
         Page<Wish> wishes = wishLowService.findByUserIdWithFestivalPage(userId, pageable);
         return wishes.map(wish -> {
@@ -52,6 +55,7 @@ public class WishService {
 
     }
 
+    // 좋아요 삭제
     @Transactional
     public void removeWish(Long wishId, Long userId) {
         Wish wish = wishLowService.findByUserIdAndId(userId, wishId);

--- a/src/test/java/kakao/festapick/chat/controller/ChatControllerTest.java
+++ b/src/test/java/kakao/festapick/chat/controller/ChatControllerTest.java
@@ -88,7 +88,7 @@ public class ChatControllerTest {
         Festival festival = saveFestival();
         ChatRoom chatRoom = new ChatRoom("test room", festival);
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
-        ChatMessage chatMessage = new ChatMessage("test message",savedChatRoom, userEntity);
+        ChatMessage chatMessage = new ChatMessage("test message", "image url", savedChatRoom, userEntity);
         chatMessageRepository.save(chatMessage);
 
         mockMvc.perform(get(String.format("/api/chatRooms/%s/messages", savedChatRoom.getId())))

--- a/src/test/java/kakao/festapick/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/kakao/festapick/chat/repository/ChatMessageRepositoryTest.java
@@ -65,7 +65,7 @@ public class ChatMessageRepositoryTest {
         ChatRoom chatRoom = saveChatRoom(festival);
 
         ChatMessage actual = chatMessageRepository.save(
-                new ChatMessage("test message", chatRoom, userEntity));
+                new ChatMessage("test message", "image url",chatRoom, userEntity));
 
         assertAll(
                 () -> AssertionsForClassTypes.assertThat(actual.getId()).isNotNull(),
@@ -83,7 +83,7 @@ public class ChatMessageRepositoryTest {
         Festival festival = saveFestival();
         ChatRoom chatRoom = saveChatRoom(festival);
 
-        chatMessageRepository.save(new ChatMessage("test message", chatRoom, userEntity));
+        chatMessageRepository.save(new ChatMessage("test message", "image url", chatRoom, userEntity));
 
         Page<ChatMessage> find = chatMessageRepository.findByChatRoomId(chatRoom.getId(), PageRequest.of(0, 1));
         ChatMessage actual = find.getContent().get(0);

--- a/src/test/java/kakao/festapick/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/kakao/festapick/chat/service/ChatMessageServiceTest.java
@@ -72,7 +72,7 @@ public class ChatMessageServiceTest {
         given(chatMessageLowService.save(any()))
                 .willReturn(chatMessage);
 
-        ChatRequestDto requestDto = new ChatRequestDto("test message", List.of(new FileUploadRequest(1L,"image")));
+        ChatRequestDto requestDto = new ChatRequestDto("test message", new FileUploadRequest(1L,"image"));
         chatMessageService.sendChat(chatRoom.getId(), requestDto, user.getId());
 
         verify(userLowService).findById(any());

--- a/src/test/java/kakao/festapick/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/kakao/festapick/chat/service/ChatMessageServiceTest.java
@@ -10,11 +10,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import kakao.festapick.chat.domain.ChatMessage;
 import kakao.festapick.chat.domain.ChatRoom;
 import kakao.festapick.chat.dto.ChatPayload;
-import kakao.festapick.chat.dto.SendChatRequestDto;
+import kakao.festapick.chat.dto.ChatRequestDto;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.dto.FestivalRequestDto;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
@@ -73,7 +72,7 @@ public class ChatMessageServiceTest {
         given(chatMessageLowService.save(any()))
                 .willReturn(chatMessage);
 
-        SendChatRequestDto requestDto = new SendChatRequestDto("test message", List.of(new FileUploadRequest(1L,"image")));
+        ChatRequestDto requestDto = new ChatRequestDto("test message", List.of(new FileUploadRequest(1L,"image")));
         chatMessageService.sendChat(chatRoom.getId(), requestDto, user.getId());
 
         verify(userLowService).findById(any());

--- a/src/test/java/kakao/festapick/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/kakao/festapick/chat/service/ChatMessageServiceTest.java
@@ -15,8 +15,6 @@ import kakao.festapick.chat.domain.ChatMessage;
 import kakao.festapick.chat.domain.ChatRoom;
 import kakao.festapick.chat.dto.ChatPayload;
 import kakao.festapick.chat.dto.SendChatRequestDto;
-import kakao.festapick.chat.repository.ChatMessageRepository;
-import kakao.festapick.chat.repository.ChatRoomRepository;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.dto.FestivalRequestDto;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
@@ -33,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,9 +44,9 @@ public class ChatMessageServiceTest {
     @Mock
     private UserLowService userLowService;
     @Mock
-    private ChatMessageRepository chatMessageRepository;
+    private ChatMessageLowService chatMessageLowService;
     @Mock
-    private ChatRoomRepository chatRoomRepository;
+    private ChatRoomLowService chatRoomLowService;
 
     @Test
     @DisplayName("채팅 전송 성공")
@@ -61,21 +58,21 @@ public class ChatMessageServiceTest {
 
         given(userLowService.findById(any()))
                 .willReturn(user);
-        given(chatRoomRepository.findById(any()))
-                .willReturn(Optional.of(chatRoom));
-        given(chatMessageRepository.save(any()))
+        given(chatRoomLowService.findByRoomId(any()))
+                .willReturn(chatRoom);
+        given(chatMessageLowService.save(any()))
                 .willReturn(chatMessage);
 
         SendChatRequestDto requestDto = new SendChatRequestDto("test message");
         chatMessageService.sendChat(chatRoom.getId(), requestDto, user.getId());
 
         verify(userLowService).findById(any());
-        verify(chatRoomRepository).findById(any());
-        verify(chatMessageRepository).save(any());
+        verify(chatRoomLowService).findByRoomId(any());
+        verify(chatMessageLowService).save(any());
         verify(webSocket).convertAndSend((String) any(), (Object) any());
-        verifyNoMoreInteractions(chatRoomRepository);
+        verifyNoMoreInteractions(chatRoomLowService);
         verifyNoMoreInteractions(userLowService);
-        verifyNoMoreInteractions(chatMessageRepository);
+        verifyNoMoreInteractions(chatMessageLowService);
         verifyNoMoreInteractions(webSocket);
     }
 
@@ -92,7 +89,7 @@ public class ChatMessageServiceTest {
 
         Page<ChatMessage> page = new PageImpl<>(messageList);
 
-        given(chatMessageRepository.findByChatRoomId(any(), any()))
+        given(chatMessageLowService.findByChatRoomId(any(), any()))
                 .willReturn(page);
 
         Page<ChatPayload> response = chatMessageService.getPreviousMessages(1L,
@@ -102,10 +99,10 @@ public class ChatMessageServiceTest {
                 () -> AssertionsForClassTypes.assertThat(response.getContent().get(0)).isNotNull()
         );
 
-        verify(chatMessageRepository).findByChatRoomId(any(), any());
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(chatMessageLowService).findByChatRoomId(any(), any());
+        verifyNoMoreInteractions(chatRoomLowService);
         verifyNoMoreInteractions(userLowService);
-        verifyNoMoreInteractions(chatMessageRepository);
+        verifyNoMoreInteractions(chatMessageLowService);
         verifyNoMoreInteractions(webSocket);
     }
 

--- a/src/test/java/kakao/festapick/chat/service/ChatParticipantServiceTest.java
+++ b/src/test/java/kakao/festapick/chat/service/ChatParticipantServiceTest.java
@@ -11,8 +11,6 @@ import java.lang.reflect.Field;
 import java.util.Optional;
 import kakao.festapick.chat.domain.ChatParticipant;
 import kakao.festapick.chat.domain.ChatRoom;
-import kakao.festapick.chat.repository.ChatParticipantRepository;
-import kakao.festapick.chat.repository.ChatRoomRepository;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.dto.FestivalRequestDto;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
@@ -32,9 +30,9 @@ public class ChatParticipantServiceTest {
     @InjectMocks
     private ChatParticipantService chatParticipantService;
     @Mock
-    private ChatParticipantRepository chatParticipantRepository;
+    private ChatParticipantLowService chatParticipantLowService;
     @Mock
-    private ChatRoomRepository chatRoomRepository;
+    private ChatRoomLowService chatRoomLowService;
     @Mock
     private UserLowService userLowService;
 
@@ -49,24 +47,24 @@ public class ChatParticipantServiceTest {
 
         ChatParticipant chatParticipant = new ChatParticipant(1L, user, chatRoom);
 
-        given(chatRoomRepository.findById(any()))
-                .willReturn(Optional.of(chatRoom));
+        given(chatRoomLowService.findByRoomId(any()))
+                .willReturn(chatRoom);
         given(userLowService.findById(any()))
                 .willReturn(user);
-        given(chatParticipantRepository.existsByUserAndChatRoom(any(), any()))
+        given(chatParticipantLowService.existsByUserAndChatRoom(any(), any()))
                 .willReturn(false);
-        given(chatParticipantRepository.save(any()))
+        given(chatParticipantLowService.save(any()))
                 .willReturn(chatParticipant);
 
         chatParticipantService.enterChatRoom(user.getId(), chatRoom.getId());
 
-        verify(chatRoomRepository).findById(any());
+        verify(chatRoomLowService).findByRoomId(any());
         verify(userLowService).findById(any());
-        verify(chatParticipantRepository).existsByUserAndChatRoom(any(),any());
-        verify(chatParticipantRepository).save(any());
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(chatParticipantLowService).existsByUserAndChatRoom(any(),any());
+        verify(chatParticipantLowService).save(any());
+        verifyNoMoreInteractions(chatRoomLowService);
         verifyNoMoreInteractions(userLowService);
-        verifyNoMoreInteractions(chatParticipantRepository);
+        verifyNoMoreInteractions(chatParticipantLowService);
     }
 
     @Test
@@ -76,21 +74,21 @@ public class ChatParticipantServiceTest {
         Festival festival = testFestival();
         ChatRoom chatRoom = new ChatRoom(1L, "test room", festival);
 
-        given(chatRoomRepository.findById(any()))
-                .willReturn(Optional.of(chatRoom));
+        given(chatRoomLowService.findByRoomId(any()))
+                .willReturn(chatRoom);
         given(userLowService.findById(any()))
                 .willReturn(user);
-        given(chatParticipantRepository.existsByUserAndChatRoom(any(), any()))
+        given(chatParticipantLowService.existsByUserAndChatRoom(any(), any()))
                 .willReturn(true);
 
         chatParticipantService.enterChatRoom(user.getId(), chatRoom.getId());
 
-        verify(chatRoomRepository).findById(any());
+        verify(chatRoomLowService).findByRoomId(any());
         verify(userLowService).findById(any());
-        verify(chatParticipantRepository).existsByUserAndChatRoom(any(),any());
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(chatParticipantLowService).existsByUserAndChatRoom(any(),any());
+        verifyNoMoreInteractions(chatRoomLowService);
         verifyNoMoreInteractions(userLowService);
-        verifyNoMoreInteractions(chatParticipantRepository);
+        verifyNoMoreInteractions(chatParticipantLowService);
     }
 
     private Festival testFestival() throws NoSuchFieldException, IllegalAccessException {

--- a/src/test/java/kakao/festapick/chat/service/ChatRoomLowServiceTest.java
+++ b/src/test/java/kakao/festapick/chat/service/ChatRoomLowServiceTest.java
@@ -1,0 +1,92 @@
+package kakao.festapick.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import kakao.festapick.chat.domain.ChatRoom;
+import kakao.festapick.chat.dto.ChatRoomResponseDto;
+import kakao.festapick.chat.repository.ChatRoomRepository;
+import kakao.festapick.festival.domain.Festival;
+import kakao.festapick.festival.dto.FestivalRequestDto;
+import kakao.festapick.festival.service.FestivalLowService;
+import kakao.festapick.festival.tourapi.TourDetailResponse;
+import kakao.festapick.global.exception.ExceptionCode;
+import kakao.festapick.global.exception.NotFoundEntityException;
+import kakao.festapick.util.TestUtil;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatRoomLowServiceTest {
+
+    private final TestUtil testUtil = new TestUtil();
+    @InjectMocks
+    private ChatRoomLowService chatRoomLowService;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Test
+    @DisplayName("방 아이디로 존재하는 채팅방 조회 성공")
+    void getExistChatRoomSuccess2() throws NoSuchFieldException, IllegalAccessException {
+        Festival festival = testFestival();
+
+        ChatRoom chatRoom = new ChatRoom(1L, "test room", festival);
+
+        given(chatRoomRepository.findByRoomId(any()))
+                .willReturn(Optional.of(chatRoom));
+
+        ChatRoom response = chatRoomLowService.findByRoomId(chatRoom.getId());
+
+        assertAll(
+                () -> AssertionsForClassTypes.assertThat(response.getId()).isNotNull(),
+                () -> AssertionsForClassTypes.assertThat(response.getRoomName())
+                        .isEqualTo("test room"),
+                () -> AssertionsForClassTypes.assertThat(response.getFestival())
+                        .isEqualTo(festival)
+        );
+
+        verify(chatRoomRepository).findByRoomId(any());
+        verifyNoMoreInteractions(chatRoomRepository);
+    }
+
+    @Test
+    @DisplayName("없는 방 아이디로 채팅방 조회 실패")
+    void getExistChatRoomFail() {
+
+        given(chatRoomRepository.findByRoomId(any()))
+                .willReturn(Optional.empty());
+
+        NotFoundEntityException e = Assertions.assertThrows(NotFoundEntityException.class,
+                () -> chatRoomLowService.findByRoomId(999L));
+
+        assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.CHATROOM_NOT_FOUND);
+
+        verify(chatRoomRepository).findByRoomId(any());
+        verifyNoMoreInteractions(chatRoomRepository);
+    }
+
+    private Festival testFestival() throws NoSuchFieldException, IllegalAccessException {
+        FestivalRequestDto festivalRequestDto = new FestivalRequestDto("12345", "example title",
+                11, "test area1", "test area2", "http://asd.example.com/test.jpg",
+                testUtil.toLocalDate("20250823"), testUtil.toLocalDate("20251231"));
+        Festival festival = new Festival(festivalRequestDto, new TourDetailResponse());
+
+        Field idField = Festival.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(festival, 1L);
+
+        return festival;
+    }
+}

--- a/src/test/java/kakao/festapick/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/kakao/festapick/chat/service/ChatRoomServiceTest.java
@@ -11,10 +11,9 @@ import java.lang.reflect.Field;
 import java.util.Optional;
 import kakao.festapick.chat.domain.ChatRoom;
 import kakao.festapick.chat.dto.ChatRoomResponseDto;
-import kakao.festapick.chat.repository.ChatRoomRepository;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.dto.FestivalRequestDto;
-import kakao.festapick.festival.repository.FestivalRepository;
+import kakao.festapick.festival.service.FestivalLowService;
 import kakao.festapick.festival.tourapi.TourDetailResponse;
 import kakao.festapick.global.exception.ExceptionCode;
 import kakao.festapick.global.exception.NotFoundEntityException;
@@ -35,9 +34,9 @@ public class ChatRoomServiceTest {
     @InjectMocks
     private ChatRoomService chatRoomService;
     @Mock
-    private ChatRoomRepository chatRoomRepository;
+    private ChatRoomLowService chatRoomLowService;
     @Mock
-    private FestivalRepository festivalRepository;
+    private FestivalLowService festivalLowService;
 
     @Test
     @DisplayName("축제 아이디로 존재하는 채팅방 조회 성공")
@@ -46,7 +45,7 @@ public class ChatRoomServiceTest {
 
         ChatRoom chatRoom = new ChatRoom(1L, "test room", festival);
 
-        given(chatRoomRepository.findByFestivalId(any()))
+        given(chatRoomLowService.findByFestivalId(any()))
                 .willReturn(Optional.of(chatRoom));
 
         ChatRoomResponseDto responseDto = chatRoomService.getExistChatRoomOrMakeByFestivalId(
@@ -60,9 +59,9 @@ public class ChatRoomServiceTest {
                         .isEqualTo(festival.getId())
         );
 
-        verify(chatRoomRepository).findByFestivalId(any());
-        verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(chatRoomLowService).findByFestivalId(any());
+        verifyNoMoreInteractions(festivalLowService);
+        verifyNoMoreInteractions(chatRoomLowService);
     }
 
     @Test
@@ -72,11 +71,11 @@ public class ChatRoomServiceTest {
 
         ChatRoom chatRoom = new ChatRoom(1L, "test room", festival);
 
-        given(chatRoomRepository.findByFestivalId(any()))
+        given(chatRoomLowService.findByFestivalId(any()))
                 .willReturn(Optional.empty());
-        given(festivalRepository.findFestivalById(any()))
-                .willReturn(Optional.of(festival));
-        given(chatRoomRepository.save(any()))
+        given(festivalLowService.findFestivalById(any()))
+                .willReturn(festival);
+        given(chatRoomLowService.save(any()))
                 .willReturn(chatRoom);
 
         ChatRoomResponseDto responseDto = chatRoomService.getExistChatRoomOrMakeByFestivalId(
@@ -90,11 +89,11 @@ public class ChatRoomServiceTest {
                         .isEqualTo(festival.getId())
         );
 
-        verify(festivalRepository).findFestivalById(any());
-        verify(chatRoomRepository).findByFestivalId(any());
-        verify(chatRoomRepository).save(any());
-        verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(festivalLowService).findFestivalById(any());
+        verify(chatRoomLowService).findByFestivalId(any());
+        verify(chatRoomLowService).save(any());
+        verifyNoMoreInteractions(festivalLowService);
+        verifyNoMoreInteractions(chatRoomLowService);
     }
 
     @Test
@@ -104,8 +103,8 @@ public class ChatRoomServiceTest {
 
         ChatRoom chatRoom = new ChatRoom(1L, "test room", festival);
 
-        given(chatRoomRepository.findByRoomId(any()))
-                .willReturn(Optional.of(chatRoom));
+        given(chatRoomLowService.findByRoomId(any()))
+                .willReturn(chatRoom);
 
         ChatRoomResponseDto responseDto = chatRoomService.getChatRoomByRoomId(festival.getId());
 
@@ -117,26 +116,26 @@ public class ChatRoomServiceTest {
                         .isEqualTo(festival.getId())
         );
 
-        verify(chatRoomRepository).findByRoomId(any());
-        verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(chatRoomLowService).findByRoomId(any());
+        verifyNoMoreInteractions(festivalLowService);
+        verifyNoMoreInteractions(chatRoomLowService);
     }
 
     @Test
     @DisplayName("없는 방 아이디로 채팅방 조회 실패")
     void getExistChatRoomFail() {
 
-        given(chatRoomRepository.findByRoomId(any()))
-                .willReturn(Optional.empty());
+        given(chatRoomLowService.findByRoomId(any()))
+                .willThrow(new NotFoundEntityException(ExceptionCode.CHATROOM_NOT_FOUND));
 
         NotFoundEntityException e = Assertions.assertThrows(NotFoundEntityException.class,
                 () -> chatRoomService.getChatRoomByRoomId(999L));
 
         assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.CHATROOM_NOT_FOUND);
 
-        verify(chatRoomRepository).findByRoomId(any());
-        verifyNoMoreInteractions(festivalRepository);
-        verifyNoMoreInteractions(chatRoomRepository);
+        verify(chatRoomLowService).findByRoomId(any());
+        verifyNoMoreInteractions(festivalLowService);
+        verifyNoMoreInteractions(chatRoomLowService);
     }
 
     private Festival testFestival() throws NoSuchFieldException, IllegalAccessException {

--- a/src/test/java/kakao/festapick/festival/controller/FestivalUserControllerTest.java
+++ b/src/test/java/kakao/festapick/festival/controller/FestivalUserControllerTest.java
@@ -330,7 +330,7 @@ class FestivalUserControllerTest {
             userRepository.save(testUser);
             wishRepository.save(new Wish(testUser, savedFestival));
             chatParticipantRepository.save(new ChatParticipant(testUser, savedChatRoom));
-            chatMessageRepository.save(new ChatMessage("test message", savedChatRoom, testUser));
+            chatMessageRepository.save(new ChatMessage("test message", "image url",savedChatRoom, testUser));
         }
 
         //when-then

--- a/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
+++ b/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
@@ -115,8 +115,8 @@ class UserControllerTest {
         chatParticipantRepository.save(new ChatParticipant(userEntity, savedChatRoom2));
 
         for (int i=0; i<5; i++) {
-            chatMessageRepository.save(new ChatMessage("test message " + i, savedChatRoom1, userEntity));
-            chatMessageRepository.save(new ChatMessage("test message " + i, savedChatRoom2, userEntity));
+            chatMessageRepository.save(new ChatMessage("test message " + i, "image url", savedChatRoom1, userEntity));
+            chatMessageRepository.save(new ChatMessage("test message " + i, "image url", savedChatRoom2, userEntity));
         }
 
         // when & then

--- a/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
+++ b/src/test/java/kakao/festapick/user/controller/UserControllerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -123,8 +124,8 @@ class UserControllerTest {
                 .andExpect(status().isNoContent());
 
         Optional<UserEntity> findUser = userRepository.findById(userEntity.getId());
-        List<ChatMessage> messages1 = chatMessageRepository.findAllByChatRoomIdAndUserId(savedChatRoom1.getId(), userEntity.getId());
-        List<ChatMessage> messages2 = chatMessageRepository.findAllByChatRoomIdAndUserId(savedChatRoom2.getId(), userEntity.getId());
+        List<ChatMessage> messages1 = chatMessageRepository.findByChatRoomId(savedChatRoom1.getId(), Pageable.unpaged()).getContent();
+        List<ChatMessage> messages2 = chatMessageRepository.findByChatRoomId(savedChatRoom2.getId(), Pageable.unpaged()).getContent();
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(findUser.isPresent()).isEqualTo(false);


### PR DESCRIPTION
## 구현 / 리팩토링 기능
- 구독 시 로직 인터셉터에서 처리하도록 변경
- Chat Room, Participant, Message의 서비스 레이어에서 Low 계층 분리
- 축제 - 채팅방 관계를 1:N에서 1:1로 변경
- 채팅에 사진 업로드 구현
  - 해당 기능을 시험하기 위해서 기존 프론트엔드 데모 앱을 업데이트할 수 있습니다
```bash
git pull
npm start
```
<img width="2728" height="1148" alt="image" src="https://github.com/user-attachments/assets/2e01250c-fee5-4ae3-ab27-689fb3e5daac" />

## 추기
- 채팅 각 도메인에 생성, 수정 날짜 컬럼을 추가하는 건 어떤가요? ERD에 없어서 만들진 않았는데 있는게 좋을거 같아요.
- #47 이 pr이 머지되면 API 명세서 작성하면서 같이 하겠습니다 api 명세서 작성 기능 pr을 먼저 머지하시면 될 것 같습니다.
