### PR TITLE
feat: areaCode가 0번인 경우에는 전국 축제 목록을 가져오기

### DIFF
--- a/src/main/java/kakao/festapick/festival/repository/FestivalRepository.java
+++ b/src/main/java/kakao/festapick/festival/repository/FestivalRepository.java
@@ -1,5 +1,7 @@
 package kakao.festapick.festival.repository;
 
+import java.util.List;
+import java.util.Optional;
 import kakao.festapick.festival.domain.Festival;
 import kakao.festapick.festival.domain.FestivalState;
 import org.springframework.data.domain.Page;
@@ -8,16 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
-
 public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
     List<Festival> findAllByState(FestivalState state);
-
-    @Query("select f from Festival f where f.areaCode = :areaCode and :today <= f.endDate and f.state = :state")
-    Page<Festival> findFestivalByAreaCodeAndDate(int areaCode, LocalDate today, FestivalState state, Pageable pageable);
 
     Optional<Festival> findFestivalById(Long id);
 

--- a/src/main/java/kakao/festapick/festival/service/FestivalLowService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalLowService.java
@@ -38,8 +38,8 @@ public class FestivalLowService {
         return festivalRepository.findAllByState(festivalState);
     }
 
-    public Page<Festival> findFestivalByAreaCodeAndDate(int areaCode, LocalDate today, FestivalState state, Pageable pageable){
-        return festivalRepository.findFestivalByAreaCodeAndDate(areaCode, today, state, pageable);
+    public Page<Festival> findFestivalByAreaCodeAndDate(Integer areaCode, LocalDate today, Pageable pageable){
+        return qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode, today, pageable);
     }
 
     public Festival findFestivalById(Long id) {

--- a/src/main/java/kakao/festapick/festival/service/FestivalService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalService.java
@@ -102,8 +102,11 @@ public class FestivalService {
 
     //지역코드와 날짜(오늘)를 통해 승인된 축제를 조회
     public Page<FestivalListResponse> findApprovedAreaAndDate(int areaCode, Pageable pageable) {
-        Page<Festival> festivalList = festivalLowService.findFestivalByAreaCodeAndDate(areaCode,
-                LocalDate.now(), FestivalState.APPROVED, pageable);
+
+        //전국이면 null(조건 없음)
+        Integer areaCodeSearch = areaCode == 0 ? null : areaCode;
+        Page<Festival> festivalList = festivalLowService.findFestivalByAreaCodeAndDate(areaCodeSearch, LocalDate.now(), pageable);
+
         return festivalList.map(festival -> {
             Double averageScore = festival.calculateReviewScore();
             long wishCount = festival.getWishCount();

--- a/src/test/java/kakao/festapick/festival/repository/FestivalRepositoryTest.java
+++ b/src/test/java/kakao/festapick/festival/repository/FestivalRepositoryTest.java
@@ -85,30 +85,6 @@ class FestivalRepositoryTest {
         );
     }
 
-    @Test
-    void findFestivalByAreaCodeAndDate() throws Exception {
-
-        //given
-        int areaCode = 1;
-
-        Festival festival1 = createFestival("FESTAPICK_111" , "카테캠축제", areaCode, testUtil.toLocalDate("20250815"), testUtil.toLocalDate("20250820"));
-        festivalRepository.save(festival1);
-
-        Festival festival2 = createFestival("FESTAPICK_222" , "스파르타축제", areaCode, testUtil.toLocalDate("20250810"), testUtil.toLocalDate("20250814"));
-        festivalRepository.save(festival2);
-
-        //when
-        Pageable pageable = PageRequest.of(0,10);
-        Page<Festival> festivals = festivalRepository.findFestivalByAreaCodeAndDate(areaCode, testUtil.toLocalDate("20250816"), FestivalState.APPROVED, pageable);
-
-        //then
-        assertAll(
-                () -> assertThat(festivals.getTotalElements()).isGreaterThan(1),
-                () -> assertThat(festivals).contains(festival1),
-                () -> assertThat(festivals).doesNotContain(festival2),
-                () -> assertThat(festivals.getContent().getFirst().getAreaCode()).isEqualTo(areaCode)
-        );
-    }
 
     @Test
     void findFestivalById() throws Exception {

--- a/src/test/java/kakao/festapick/festival/repository/QFestivalRepositoryTest.java
+++ b/src/test/java/kakao/festapick/festival/repository/QFestivalRepositoryTest.java
@@ -1,0 +1,96 @@
+package kakao.festapick.festival.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import jakarta.persistence.EntityManager;
+import java.util.stream.Collectors;
+import kakao.festapick.festival.domain.Festival;
+import kakao.festapick.util.TestUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class QFestivalRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private QFestivalRepository qFestivalRepository;
+
+    @Autowired
+    private FestivalRepository festivalRepository;
+
+    private TestUtil testUtil = new TestUtil();
+
+    @BeforeEach
+    void init() {
+        qFestivalRepository = new QFestivalRepository(entityManager);
+    }
+
+    @Test
+    @DisplayName("지역 코드를 통해 축제를 조회하는 경우")
+    void findFestivalByAreaCodeAndDate() {
+        //given
+        int areaCode = 1;
+
+        Festival festival1 = createFestivalAndSaveByAreaCode(areaCode);
+        createFestivalAndSaveByAreaCode(areaCode);
+        createFestivalAndSaveByAreaCode(3);
+
+        //when
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Festival> festivals = qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode,
+                testUtil.toLocalDate("20250816"), pageable);
+
+        //then
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(festivals.getTotalElements()).isEqualTo(2);
+                    softly.assertThat(festivals).contains(festival1);
+                    softly.assertThat(festivals.getContent().getFirst().getAreaCode())
+                            .isEqualTo(areaCode);
+                });
+    }
+
+    @Test
+    @DisplayName("전국 축제를 조회하는 경우")
+    void findAllFestivalAndDate() {
+        //given
+        Integer areaCode = null;
+
+        Festival festival1 = createFestivalAndSaveByAreaCode(1);
+        Festival festival2 = createFestivalAndSaveByAreaCode(2);
+        createFestivalAndSaveByAreaCode(3);
+        createFestivalAndSaveByAreaCode(4);
+
+        //when
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<Festival> festivals = qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode,
+                testUtil.toLocalDate("20250816"), pageable);
+
+        //then
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(festivals.getTotalElements()).isEqualTo(4);
+                    softly.assertThat(festivals).contains(festival1);
+                    softly.assertThat(festivals).contains(festival2);
+                    softly.assertThat(festivals.getContent().stream().map(Festival::getAreaCode)
+                            .collect(Collectors.toSet()).size()).isEqualTo(4);
+                });
+    }
+
+
+    private Festival createFestivalAndSaveByAreaCode(int areaCode) {
+        return festivalRepository.save(testUtil.createTestFestivalByAreaCode(areaCode));
+    }
+
+}

--- a/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
+++ b/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
@@ -199,7 +199,7 @@ class FestivalServiceTest {
         List<Festival> festivals = getFestivals();
         Page<Festival> pagedFestivals = new PageImpl<>(festivals, pageable, 10);
 
-        given(festivalLowService.findFestivalByAreaCodeAndDate(anyInt(), any(), any(), any())).willReturn(pagedFestivals);
+        given(festivalLowService.findFestivalByAreaCodeAndDate(anyInt(), any(), any())).willReturn(pagedFestivals);
 
         //when
         Page<FestivalListResponse> festivalList = festivalService.findApprovedAreaAndDate(areaCode, pageable);
@@ -211,7 +211,7 @@ class FestivalServiceTest {
                 () -> assertThat(festivalList.getContent().getFirst()).isInstanceOf(FestivalListResponse.class)
         );
 
-        verify(festivalLowService).findFestivalByAreaCodeAndDate(anyInt(), any(), any(), any());
+        verify(festivalLowService).findFestivalByAreaCodeAndDate(anyInt(), any(), any());
         verifyNoMoreInteractions(festivalLowService, wishLowService);
     }
 

--- a/src/test/java/kakao/festapick/util/TestUtil.java
+++ b/src/test/java/kakao/festapick/util/TestUtil.java
@@ -56,6 +56,10 @@ public class TestUtil {
         return new Festival("카테캠축제", 1,"주소1", null, "postImageUrl",toLocalDate("20250810"), toLocalDate("20250820"),"overView", "hompage", FestivalState.APPROVED, null, null);
     }
 
+    public Festival createTestFestivalByAreaCode(int areaCode) {
+        return new Festival("축제", areaCode,"주소1", null, "postImageUrl",toLocalDate("20250810"), toLocalDate("20250820"),"overView", "hompage", FestivalState.APPROVED, null, null);
+    }
+
     public ChatRoom createTestChatRoom(Festival festival) {
         return new ChatRoom("test room", festival);
     }


### PR DESCRIPTION
close: #58 
- areaCode가 0이면 별도의 조건 없이 모든 축제(전국 축제 조회)를 가져오도록 구현했습니다.
  - 입력된 지역코드가 0일 경우에는 지역코드를 null로 처리하여 where 조건이 적용되지 않도록 설정했습니다.
  - 입력된 지역코드가 0이 아닌 경우에는 해당 지역코드를 조건으로 축제를 조회하도록 했습니다.
- 이를 위해 QueryDSL을 활용했습니다.

| ![지역 코드 6](https://github.com/user-attachments/assets/706f5df0-71c4-4595-b906-51f16d7f8180) | ![지역 코드 0](https://github.com/user-attachments/assets/086b7b3b-c5a4-4f77-9b3d-4669d05e1ba7) |
|:-----------------------------------------------:|:-----------------------------------------------:|
| **지역 코드가 6(부산)인 경우**                   | **지역 코드가 0(전국)인 경우**                   |

 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved festival browsing by area or nationwide (when no area is selected).
  * Results now consistently show approved festivals that are ongoing as of the chosen date, with full pagination support.
* **Refactor**
  * Streamlined backend query logic for festival listings to align filters and reduce complexity.
* **Tests**
  * Added comprehensive tests for area/date filtering scenarios and supporting test utilities.
  * Updated existing tests to reflect the simplified service method signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->