### PR TITLE
refactor: 현재 진행중인 축제와 종료된 축제를 구분

### DIFF
--- a/src/main/java/kakao/festapick/festival/controller/FestivalUserController.java
+++ b/src/main/java/kakao/festapick/festival/controller/FestivalUserController.java
@@ -52,9 +52,9 @@ public class FestivalUserController {
             @PathVariable int areaCode,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int size,
-            @RequestParam(defaultValue = "true") boolean now
+            @RequestParam(defaultValue = "true") boolean current
     ){
-        Page<FestivalListResponse> festivalResponseDtos = festivalService.findApprovedAreaAndDate(areaCode, now, PageRequest.of(page, size));
+        Page<FestivalListResponse> festivalResponseDtos = festivalService.findApprovedAreaAndDate(areaCode, current, PageRequest.of(page, size));
         return ResponseEntity.ok(festivalResponseDtos);
     }
 

--- a/src/main/java/kakao/festapick/festival/repository/QFestivalRepository.java
+++ b/src/main/java/kakao/festapick/festival/repository/QFestivalRepository.java
@@ -57,12 +57,12 @@ public class QFestivalRepository {
         return type != null ? festival.festivalType.eq(type) : null;
     }
 
-    public Page<Festival> findFestivalByAreaCodeAndDate(Integer areaCode, LocalDate now, Pageable pageable){
+    public Page<Festival> findFestivalByAreaCodeAndDate(Integer areaCode, boolean current, Pageable pageable){
 
         List<Festival> content = queryFactory
                 .select(festival)
                 .from(festival)
-                .where(areaCodeEq(areaCode), festival.state.eq(FestivalState.APPROVED), dateGoe(now))
+                .where(areaCodeEq(areaCode), festival.state.eq(FestivalState.APPROVED), filterByFestivalDate(current))
                 .orderBy(festival.endDate.desc(), festival.id.desc())
                 .offset(pageable.getOffset()) // 페이지 시작 번호
                 .limit(pageable.getPageSize()) // 페이지 사이즈
@@ -71,7 +71,7 @@ public class QFestivalRepository {
         JPAQuery<Long> countQuery = queryFactory
                 .select(festival.count())
                 .from(festival)
-                .where(areaCodeEq(areaCode), festival.state.eq(FestivalState.APPROVED), dateGoe(now));
+                .where(areaCodeEq(areaCode), festival.state.eq(FestivalState.APPROVED), filterByFestivalDate(current));
 
         return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetchOne());
     }
@@ -80,8 +80,8 @@ public class QFestivalRepository {
         return areaCode == null ? null : festival.areaCode.eq(areaCode); // 조건을 반환
     }
 
-    private BooleanExpression dateGoe(LocalDate now){
-        return now == null ? null : festival.endDate.goe(now); // 조건을 반환
+    private BooleanExpression filterByFestivalDate(boolean current){
+        LocalDate now = LocalDate.now();
+        return current ? festival.endDate.goe(now) : festival.endDate.lt(now); // 조건을 반환
     }
-
 }

--- a/src/main/java/kakao/festapick/festival/service/FestivalLowService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalLowService.java
@@ -39,8 +39,8 @@ public class FestivalLowService {
         return festivalRepository.findAllByState(festivalState);
     }
 
-    public Page<Festival> findFestivalByAreaCodeAndDate(Integer areaCode, LocalDate today, Pageable pageable){
-        return qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode, today, pageable);
+    public Page<Festival> findFestivalByAreaCodeAndDate(Integer areaCode, boolean current, Pageable pageable){
+        return qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode, current, pageable);
     }
 
     public Festival findFestivalById(Long id) {

--- a/src/main/java/kakao/festapick/festival/service/FestivalService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalService.java
@@ -103,12 +103,10 @@ public class FestivalService {
     }
 
     //지역코드와 날짜를 통해 승인된 축제를 조회
-    public Page<FestivalListResponse> findApprovedAreaAndDate(int areaCode, boolean now, Pageable pageable) {
+    public Page<FestivalListResponse> findApprovedAreaAndDate(int areaCode, boolean current, Pageable pageable) {
         //전국이면 null(조건 없음)
         Integer areaCodeSearch = areaCode == 0 ? null : areaCode;
-        LocalDate localDate = now ? LocalDate.now() : null;
-        Page<Festival> festivalList = festivalLowService.findFestivalByAreaCodeAndDate(areaCodeSearch, localDate, pageable);
-
+        Page<Festival> festivalList = festivalLowService.findFestivalByAreaCodeAndDate(areaCodeSearch, current, pageable);
         return festivalList.map(this::getFestivalListResponse);
     }
 

--- a/src/test/java/kakao/festapick/festival/repository/QFestivalRepositoryTest.java
+++ b/src/test/java/kakao/festapick/festival/repository/QFestivalRepositoryTest.java
@@ -56,8 +56,7 @@ class QFestivalRepositoryTest {
 
         //when
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Festival> festivals = qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode,
-                testUtil.toLocalDate("20250816"), pageable);
+        Page<Festival> festivals = qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode, false, pageable);
 
         //then
         assertSoftly(
@@ -82,8 +81,7 @@ class QFestivalRepositoryTest {
 
         //when
         Pageable pageable = PageRequest.of(0, 5);
-        Page<Festival> festivals = qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode,
-                testUtil.toLocalDate("20250816"), pageable);
+        Page<Festival> festivals = qFestivalRepository.findFestivalByAreaCodeAndDate(areaCode, false, pageable);
 
         //then
         assertSoftly(

--- a/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
+++ b/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
@@ -222,7 +223,7 @@ class FestivalServiceTest {
 
         boolean now = true;
 
-        given(festivalLowService.findFestivalByAreaCodeAndDate(anyInt(), any(), any())).willReturn(pagedFestivals);
+        given(festivalLowService.findFestivalByAreaCodeAndDate(anyInt(), anyBoolean(), any())).willReturn(pagedFestivals);
 
         //when
         Page<FestivalListResponse> festivalList = festivalService.findApprovedAreaAndDate(areaCode, now, pageable);
@@ -234,7 +235,7 @@ class FestivalServiceTest {
                 () -> assertThat(festivalList.getContent().getFirst()).isInstanceOf(FestivalListResponse.class)
         );
 
-        verify(festivalLowService).findFestivalByAreaCodeAndDate(anyInt(), any(), any());
+        verify(festivalLowService).findFestivalByAreaCodeAndDate(anyInt(), anyBoolean(), any());
         verifyNoMoreInteractions(festivalLowService, wishLowService);
     }
 


### PR DESCRIPTION
- 현재 진행중인 축제와, 이미 종료된 축제를 구분해서 조회할 수 있도록 했습니다.

- current가 true인 경우 현재 진행 중인 축제를, false인 경우에는 종료된 축제를 조회할 수 있습니다.