### PR TITLE
fix: s3에서 축제 포스터가 삭제 되지 않는 현상 해결

### DIFF
--- a/src/main/java/kakao/festapick/festival/service/FestivalService.java
+++ b/src/main/java/kakao/festapick/festival/service/FestivalService.java
@@ -179,6 +179,7 @@ public class FestivalService {
 
         //축제 삭제 시 관련 이미지를 모두 삭제
         fileService.deleteByDomainId(festival.getId(), DomainType.FESTIVAL);
+        s3Service.deleteS3File(festival.getPosterInfo());
     }
 
     @Transactional

--- a/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
+++ b/src/test/java/kakao/festapick/festival/service/FestivalServiceTest.java
@@ -365,7 +365,8 @@ class FestivalServiceTest {
         verify(wishLowService).deleteByFestivalId(festival.getId());
         verify(festivalPermissionService).deleteFestivalPermissionByFestivalId(festival.getId());
         verify(festivalNoticeService).deleteByFestivalId(any());
-        verifyNoMoreInteractions(festivalLowService,fileService,reviewService,wishLowService, recommendationHistoryLowService, festivalPermissionService);
+        verify(s3Service).deleteS3File(any());
+        verifyNoMoreInteractions(festivalLowService,fileService,reviewService,wishLowService, recommendationHistoryLowService, festivalPermissionService,s3Service);
     }
 
     @Test


### PR DESCRIPTION
close: #89 

축제 삭제에서 포스터에대한 s3 삭제 요청을 하지 않았던 문제를 해결했습니다. 