### PR TITLE
dto, 엔티티 검증 추가

### DIFF
--- a/src/main/java/kakao/festapick/chat/domain/ChatMessage.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatMessage.java
@@ -25,7 +25,6 @@ public class ChatMessage extends BaseTimeEntity {
     private Long id;
 
     @Column(name = "content", nullable = false, length = 255)
-    @Size(max = 255)
     private String content;
 
     private String imageUrl;

--- a/src/main/java/kakao/festapick/chat/domain/ChatRoom.java
+++ b/src/main/java/kakao/festapick/chat/domain/ChatRoom.java
@@ -24,7 +24,7 @@ public class ChatRoom extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "roomName", nullable = false, length = 255)
+    @Column(name = "roomName", nullable = false, length = 300)
     private String roomName;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
+++ b/src/main/java/kakao/festapick/chat/dto/ChatRequestDto.java
@@ -1,10 +1,12 @@
 package kakao.festapick.chat.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 
 public record ChatRequestDto(
         @NotBlank
+        @Size(max = 255, message = "채팅은 최대 255자 까지 작성 가능합니다.")
         String content,
         FileUploadRequest imageInfo
 ) {

--- a/src/main/java/kakao/festapick/festival/domain/Festival.java
+++ b/src/main/java/kakao/festapick/festival/domain/Festival.java
@@ -35,18 +35,19 @@ public class Festival extends BaseTimeEntity {
     @Column(unique = true)
     private String contentId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     private String title;
 
     private int areaCode;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     private String addr1;
 
+    @Column(length = 255)
     private String addr2;
 
     @Column(nullable = false)
-    private String posterInfo;
+    private String posterInfo; // presigned url
 
     @Column(nullable = false)
     private LocalDate startDate;

--- a/src/main/java/kakao/festapick/festival/dto/FestivalCustomRequestDto.java
+++ b/src/main/java/kakao/festapick/festival/dto/FestivalCustomRequestDto.java
@@ -1,7 +1,9 @@
 package kakao.festapick.festival.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 import org.hibernate.validator.constraints.Length;
 
@@ -10,21 +12,26 @@ import java.util.List;
 
 public record FestivalCustomRequestDto(
         @NotBlank
+        @Size(max = 255, message = "축제 제목은 최대 255자 까지 가능합니다.")
         String title,
 
         int areaCode,
 
         @NotBlank
+        @Size(max = 255, message = "주소는 최대 255자 까지 가능합니다.")
         String addr1,
 
+        @Size(max = 255, message = "상세 주소는 최대 255자 까지 가능합니다.")
         String addr2,
 
         //poster - 포스터는 한장만(필수)
         @NotNull
+        @Valid
         FileUploadRequest posterInfo,
 
         // 축제 관련 이미지는 여러장 업로드 가능
-        List<FileUploadRequest> imageInfos,
+        @Size(max = 10, message = "축제 이미지는 최대 10장까지 업로드할 수 있습니다.")
+        List<@Valid FileUploadRequest> imageInfos,
 
         @NotNull
         LocalDate startDate,
@@ -32,10 +39,11 @@ public record FestivalCustomRequestDto(
         @NotNull
         LocalDate endDate,
 
+        @Size(max = 500, message = "홈페이지 주소는 최대 500자 까지 작성 가능합니다.")
         String homePage,
 
         @NotNull
-        @Length(min = 30, max = 5000)
+        @Size(min = 30, max = 5000, message = "축제 개요는 최소 30자 최대 5000자 작성 가능합니다.")
         String overView
 ) {
 

--- a/src/main/java/kakao/festapick/festival/dto/FestivalSearchCondForAdmin.java
+++ b/src/main/java/kakao/festapick/festival/dto/FestivalSearchCondForAdmin.java
@@ -1,9 +1,11 @@
 package kakao.festapick.festival.dto;
 
+import jakarta.validation.constraints.Size;
 import kakao.festapick.festival.domain.FestivalState;
 import kakao.festapick.festival.domain.FestivalType;
 
 public record FestivalSearchCondForAdmin(
+        @Size(max = 255, message = "축제 제목은 최대 255자 까지 가능합니다.")
         String title,
         FestivalState state,
         FestivalType festivalType

--- a/src/main/java/kakao/festapick/festival/dto/FestivalSearchCondForAdmin.java
+++ b/src/main/java/kakao/festapick/festival/dto/FestivalSearchCondForAdmin.java
@@ -5,7 +5,6 @@ import kakao.festapick.festival.domain.FestivalState;
 import kakao.festapick.festival.domain.FestivalType;
 
 public record FestivalSearchCondForAdmin(
-        @Size(max = 255, message = "축제 제목은 최대 255자 까지 가능합니다.")
         String title,
         FestivalState state,
         FestivalType festivalType

--- a/src/main/java/kakao/festapick/festival/dto/FestivalUpdateRequestDto.java
+++ b/src/main/java/kakao/festapick/festival/dto/FestivalUpdateRequestDto.java
@@ -1,7 +1,9 @@
 package kakao.festapick.festival.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 import org.hibernate.validator.constraints.Length;
 
@@ -11,19 +13,24 @@ import java.util.List;
 public record FestivalUpdateRequestDto(
 
         @NotBlank
+        @Size(max = 255, message = "축제 제목은 최대 255자 까지 가능합니다.")
         String title,
 
         int areaCode,
 
         @NotBlank
+        @Size(max = 255, message = "주소는 최대 255자 까지 가능합니다.")
         String addr1,
 
+        @Size(max = 255, message = "상세 주소는 최대 255자 까지 가능합니다.")
         String addr2,
 
         @NotNull
+        @Valid
         FileUploadRequest posterInfo,
 
-        List<FileUploadRequest> imageInfos,
+        @Size(max = 10, message = "사진은 최대 10장 까지 업로드 가능합니다.")
+        List<@Valid FileUploadRequest> imageInfos,
 
         @NotNull
         LocalDate startDate,
@@ -31,10 +38,11 @@ public record FestivalUpdateRequestDto(
         @NotNull
         LocalDate endDate,
 
+        @Size(max = 500, message = "홈페이지 주소는 최대 500자 까지 가능합니다.")
         String homePage,
 
         @NotBlank
-        @Length(min = 30, max = 5000)
+        @Size(min = 30, max = 5000, message = "축제 개요는 최소 30자 최대 5000자 까지 가능합니다.")
         String overView
 )
 {}

--- a/src/main/java/kakao/festapick/festivalnotice/domain/FestivalNotice.java
+++ b/src/main/java/kakao/festapick/festivalnotice/domain/FestivalNotice.java
@@ -1,5 +1,6 @@
 package kakao.festapick.festivalnotice.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,8 +21,10 @@ public class FestivalNotice extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 100)
     private String title;
 
+    @Column(nullable = false, length = 2000)
     private String content;
 
     @ManyToOne

--- a/src/main/java/kakao/festapick/festivalnotice/dto/FestivalNoticeRequestDto.java
+++ b/src/main/java/kakao/festapick/festivalnotice/dto/FestivalNoticeRequestDto.java
@@ -2,16 +2,20 @@ package kakao.festapick.festivalnotice.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 
 public record FestivalNoticeRequestDto(
         @NotBlank
+        @Size(max = 100, message = "공지사항 제목은 최대 100자입니다.")
         String title,
 
         @NotBlank
+        @Size(max = 2000, message = "공지사항 내용은 최대 2000자입니다.")
         String content,
 
+        @Size(max = 10, message = "공지사항 사진은 최대 10장 업로드 가능합니다.")
         List<@Valid FileUploadRequest> images
 ) {
 }

--- a/src/main/java/kakao/festapick/permission/festivalpermission/dto/FestivalPermissionRequestDto.java
+++ b/src/main/java/kakao/festapick/permission/festivalpermission/dto/FestivalPermissionRequestDto.java
@@ -6,7 +6,7 @@ import java.util.List;
 import kakao.festapick.fileupload.dto.FileUploadRequest;
 
 public record FestivalPermissionRequestDto(
-        @Size(min = 1,message = "최소 1개 이상의 서류를 업로드해야합니다.")
+        @Size(min = 1, max = 5, message = "최소 1개, 최대 5개의 서류를 업로드해야합니다.")
         List<@Valid FileUploadRequest> documents
 )
 { }

--- a/src/main/java/kakao/festapick/permission/fmpermission/domain/FMPermission.java
+++ b/src/main/java/kakao/festapick/permission/fmpermission/domain/FMPermission.java
@@ -26,7 +26,7 @@ public class FMPermission extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String department;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/kakao/festapick/permission/fmpermission/dto/FMPermissionRequestDto.java
+++ b/src/main/java/kakao/festapick/permission/fmpermission/dto/FMPermissionRequestDto.java
@@ -8,6 +8,7 @@ import kakao.festapick.fileupload.dto.FileUploadRequest;
 
 public record FMPermissionRequestDto(
         @NotBlank(message = "소속 기관 입력은 필수입니다.")
+        @Size(min = 2, max = 50, message = "소속 기관 명은 최소 2자, 최대 50자 입력 가능합니다.")
         String department,
 
         @Size(min = 1,message = "최소 1개 이상의 서류를 업로드해야합니다.")

--- a/src/main/java/kakao/festapick/permission/fmpermission/dto/FMPermissionRequestDto.java
+++ b/src/main/java/kakao/festapick/permission/fmpermission/dto/FMPermissionRequestDto.java
@@ -11,7 +11,7 @@ public record FMPermissionRequestDto(
         @Size(min = 2, max = 50, message = "소속 기관 명은 최소 2자, 최대 50자 입력 가능합니다.")
         String department,
 
-        @Size(min = 1,message = "최소 1개 이상의 서류를 업로드해야합니다.")
+        @Size(min = 1, max = 5, message = "최소 1개, 최대 5개의 서류를 업로드해야합니다.")
         List<@Valid FileUploadRequest> documents
 )
 { }

--- a/src/main/java/kakao/festapick/review/dto/ReviewRequestDto.java
+++ b/src/main/java/kakao/festapick/review/dto/ReviewRequestDto.java
@@ -14,6 +14,7 @@ public record ReviewRequestDto(
         @Min(value = 1, message = "점수는 최소 1점에서 최대 5점 까지 가능합니다")
         @Max(value = 5, message = "점수는 최소 1점에서 최대 5점 까지 가능합니다")
         Integer score,
+        @Size(max = 10, message = "이미지는 최대 10장 까지 업로드 가능합니다.")
         List<FileUploadRequest> imageInfos,
         FileUploadRequest videoInfo // 일단 video url은 한개만 제한
 ) {

--- a/src/main/resources/templates/admin/festival-permission-management.html
+++ b/src/main/resources/templates/admin/festival-permission-management.html
@@ -2,7 +2,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>축제 관리자(Festival-Permission)신청 관리</title>
+  <title>축제 관리(Festival-Permission)신청 관리</title>
   <style>
     :root { --blue:#2563eb; --blue-dark:#1e40af; --gray:#e5e7eb; --text:#111827; }
     *{box-sizing:border-box}
@@ -39,7 +39,7 @@
 </head>
 <tourApiBody>
 
-  <h1>축제 관리자(Festival-Permission) 신청 관리</h1>
+  <h1>축제 관리(Festival-Permission) 신청 관리</h1>
   <div class="topbar" style="display:flex; gap:8px; align-items:center">
     <div th:replace="~{admin/fragments :: adminHome('관리자 홈')}"></div>
     <div th:replace="~{admin/fragments :: logout(@{/admin/logout}, '로그아웃')}"></div>

--- a/src/test/java/kakao/festapick/festival/controller/FestivalUserControllerTest.java
+++ b/src/test/java/kakao/festapick/festival/controller/FestivalUserControllerTest.java
@@ -241,7 +241,7 @@ class FestivalUserControllerTest {
         Festival festival = createCustomFestival("축제1", 1, testUtil.toLocalDate("20250803"), testUtil.toLocalDate("20250805"), user);
         Festival saved = festivalRepository.save(festival);
 
-        FestivalUpdateRequestDto updateInfo = createUpdateInfo("카테캠 축제 시즌 3", "카테캠 포스터", null);
+        FestivalUpdateRequestDto updateInfo = createUpdateInfo("카테캠 축제 시즌 3", "https://kakao-poster.com", null);
         String updateRequest = objectMapper.writeValueAsString(updateInfo);
 
         //when-then
@@ -258,7 +258,7 @@ class FestivalUserControllerTest {
         assertAll(
                 () -> assertThat(content.id()).isEqualTo(saved.getId()),
                 () -> assertThat(content.title()).isEqualTo("카테캠 축제 시즌 3"),
-                () -> assertThat(content.posterInfo()).isEqualTo("카테캠 포스터")
+                () -> assertThat(content.posterInfo()).isEqualTo("https://kakao-poster.com")
         );
     }
 
@@ -278,7 +278,7 @@ class FestivalUserControllerTest {
         images.add(new FileUploadRequest(99L, "https://festapick.firstimage.com"));
         images.add(new FileUploadRequest(9999L,"https://festapick.newimage.com"));
 
-        FestivalUpdateRequestDto festivalUpdateRequestDto = createUpdateInfo("카테캠 축제", "카테캠 포스터", images);
+        FestivalUpdateRequestDto festivalUpdateRequestDto = createUpdateInfo("카테캠 축제", "https://kakao-poster.com", images);
         String updateRequest = objectMapper.writeValueAsString(festivalUpdateRequestDto);
 
         //when-then
@@ -443,7 +443,7 @@ class FestivalUserControllerTest {
         String overview = "The overview is a section for writing a description of the festival, and it must contain at least 50 characters.";
         return new FestivalCustomRequestDto(
                 title, areaCode, "addr1", "addr2",
-                new FileUploadRequest(1L,"imageUrl"), testUtil.createFestivalImages(), startDate, endDate, "homePage", overview
+                new FileUploadRequest(1L,"https://festapick-image.com"), testUtil.createFestivalImages(), startDate, endDate, "homePage", overview
         );
     }
 


### PR DESCRIPTION
### 변경사항
누락되었던 dto, 엔티티 검증을 추가하였습니다
- 채팅 메시지 dto 사이즈 제한
- 축제 도메인 및 dto 검증 추가
- 축제 공지 도메인 및 dto 검증 추가
- FMPermission 도메인 및 dto 검증 추가
- FMPermission, FestivalPermission의 문서 업로드에 5개 제한 추가
- 리뷰 사진 개수 최대  10장 제한 추가